### PR TITLE
Enable analysis runners on push to master

### DIFF
--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -1,6 +1,8 @@
 name: Code Analysis
 
 on:
+  push:
+    branches: [master, develop]
   pull_request:
     branches: [master, develop]
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  push:
+    branches: [master, develop]
   pull_request:
     branches: [master, develop]
 


### PR DESCRIPTION
Add `push` to master as a trigger for coverage and analysis actions.