### PR TITLE
chore: try to use latest foundry build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-54d8510c0f2b0f791f4c5ef99866c6af99b7606a
 
       - run: corepack enable
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,10 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        # Use a specific version of Foundry in case nightly is broken
+        # https://github.com/foundry-rs/foundry/releases
+        # with:
+        #   version: nightly-54d8510c0f2b0f791f4c5ef99866c6af99b7606a
 
       - run: corepack enable
 


### PR DESCRIPTION
The main issue has been resolved https://github.com/foundry-rs/foundry/issues/7961
We can now use Foundry `nightly` builds until the next crash... 