### PR TITLE
fix: integration tests hardhat node version

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       hardhat-node:
-        image: feofanov/hardhat-node
+        image: feofanov/hardhat-node:2.22.4
         ports:
           - 8545:8545
         env:


### PR DESCRIPTION
Fix version for CI Hardhat node runner, `latest` version is broken.