### PR TITLE
feat: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# any PR to `master` branch with changes to production contracts notifies the protocol team
-contracts @lidofinance/lido-eth-protocol
+# Any PR to `master` branch with changes to production contracts notifies the protocol team
+/contracts/ @lidofinance/lido-eth-protocol
 
-# any PR to `master` branch with changes to GitHub workflows notifies the workflow review team
-.github @lidofinance/review-gh-workflows
+# Any PR to `master` branch with changes to GitHub workflows notifies the workflow review team
+/.github/workflows/ @lidofinance/review-gh-workflows


### PR DESCRIPTION
- Uses root level `/contracts/` directory to notify **team-protocol** group
- Uses `/.github/workflows/` directory to notify **review-gh-workflows** group