### PR TITLE
Feat/sr 1.5 ackee audit

### DIFF
--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -1353,6 +1353,7 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
         _saveOperatorStuckPenaltyStats(_nodeOperatorId, stuckPenaltyStats);
         _updateSummaryMaxValidatorsCount(_nodeOperatorId);
         _increaseValidatorsKeysNonce();
+        return true;
     }
 
     /// @notice Returns total number of node operators

--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -421,7 +421,7 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
         _authP(SET_NODE_OPERATOR_LIMIT_ROLE, arr(uint256(_nodeOperatorId), uint256(_vettedSigningKeysCount)));
         _onlyCorrectNodeOperatorState(getNodeOperatorIsActive(_nodeOperatorId));
 
-        _updateVettedSingingKeysCount(_nodeOperatorId, _vettedSigningKeysCount, true /* _allowIncrease */);
+        _updateVettedSigningKeysCount(_nodeOperatorId, _vettedSigningKeysCount, true /* _allowIncrease */);
         _increaseValidatorsKeysNonce();
     }
 
@@ -460,12 +460,12 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
                 i := add(i, 1)
             }
             _requireValidRange(nodeOperatorId < totalNodeOperatorsCount);
-            _updateVettedSingingKeysCount(nodeOperatorId, vettedKeysCount, false /* only decrease */);
+            _updateVettedSigningKeysCount(nodeOperatorId, vettedKeysCount, false /* only decrease */);
         }
         _increaseValidatorsKeysNonce();
     }
 
-    function _updateVettedSingingKeysCount(
+    function _updateVettedSigningKeysCount(
         uint256 _nodeOperatorId,
         uint256 _vettedSigningKeysCount,
         bool _allowIncrease

--- a/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
+++ b/contracts/0.4.24/nos/NodeOperatorsRegistry.sol
@@ -61,6 +61,7 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
     );
     event TargetValidatorsCountChanged(uint256 indexed nodeOperatorId, uint256 targetValidatorsCount, uint256 targetLimitMode);
     event NodeOperatorPenalized(address indexed recipientAddress, uint256 sharesPenalizedAmount);
+    event NodeOperatorPenaltyCleared(uint256 indexed nodeOperatorId);
 
     // Enum to represent the state of the reward distribution process
     enum RewardDistributionState {
@@ -1353,6 +1354,8 @@ contract NodeOperatorsRegistry is AragonApp, Versioned {
         _saveOperatorStuckPenaltyStats(_nodeOperatorId, stuckPenaltyStats);
         _updateSummaryMaxValidatorsCount(_nodeOperatorId);
         _increaseValidatorsKeysNonce();
+
+        emit NodeOperatorPenaltyCleared(_nodeOperatorId);
         return true;
     }
 

--- a/contracts/0.8.9/StakingRouter.sol
+++ b/contracts/0.8.9/StakingRouter.sol
@@ -69,6 +69,7 @@ contract StakingRouter is AccessControlEnumerable, BeaconChainDepositor, Version
     error UnrecoverableModuleError();
     error InvalidPriorityExitShareThreshold();
     error InvalidMinDepositBlockDistance();
+    error InvalidMaxDepositPerBlockValue();
 
     enum StakingModuleStatus {
         Active, // deposits and rewards allowed
@@ -337,7 +338,8 @@ contract StakingRouter is AccessControlEnumerable, BeaconChainDepositor, Version
         if (_priorityExitShareThreshold > TOTAL_BASIS_POINTS) revert InvalidPriorityExitShareThreshold();
         if (_stakeShareLimit > _priorityExitShareThreshold) revert InvalidPriorityExitShareThreshold();
         if (_stakingModuleFee + _treasuryFee > TOTAL_BASIS_POINTS) revert InvalidFeeSum();
-        if (_minDepositBlockDistance == 0) revert InvalidMinDepositBlockDistance();
+        if (_minDepositBlockDistance == 0 || _minDepositBlockDistance > type(uint64).max) revert InvalidMinDepositBlockDistance();
+        if (_maxDepositsPerBlock > type(uint64).max) revert InvalidMaxDepositPerBlockValue();
 
         stakingModule.stakeShareLimit = uint16(_stakeShareLimit);
         stakingModule.priorityExitShareThreshold = uint16(_priorityExitShareThreshold);

--- a/test/0.4.24/nor/nor.rewards.penalties.flow.test.ts
+++ b/test/0.4.24/nor/nor.rewards.penalties.flow.test.ts
@@ -737,13 +737,17 @@ describe("NodeOperatorsRegistry:rewards-penalties", () => {
         .to.emit(nor, "KeysOpIndexSet")
         .withArgs(nonce + 3n)
         .to.emit(nor, "NonceChanged")
-        .withArgs(nonce + 3n);
+        .withArgs(nonce + 3n)
+        .to.emit(nor, "NodeOperatorPenaltyCleared")
+        .withArgs(firstNodeOperatorId);
 
       await expect(await nor.clearNodeOperatorPenalty(secondNodeOperatorId))
         .to.emit(nor, "KeysOpIndexSet")
         .withArgs(nonce + 4n)
         .to.emit(nor, "NonceChanged")
-        .withArgs(nonce + 4n);
+        .withArgs(nonce + 4n)
+        .to.emit(nor, "NodeOperatorPenaltyCleared")
+        .withArgs(secondNodeOperatorId);
 
       expect(await nor.isOperatorPenalized(firstNodeOperatorId)).to.be.false;
       expect(await nor.isOperatorPenalized(secondNodeOperatorId)).to.be.false;


### PR DESCRIPTION
Fixes for ackee audit. Each commit contains the fix for a single finding.

- L1: Overflow on type casting
- L2: Potential revert on underflow.
- L3: The clearNodeOperatorPenalty returns always false
- I2: Missing event on clearNodeOperatorPenalty
- I3: Typos

Note. The commit for L2 (Potential revert on underflow) also contains contract size optimization (necessary to fit contract size in the 24 KiB limit).