### PR TITLE
ci: fix master coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Coverage
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [ master ]
 
 jobs:
   coverage:


### PR DESCRIPTION
Currently, the master branch coverage is not being collected because the workflow only runs on PRs. It also needs to run on push to master to update the reference coverage.