### PR TITLE
refactor: Add fastLaneLengthSlots to getFrameConfig interface

### DIFF
--- a/contracts/0.4.24/oracle/LegacyOracle.sol
+++ b/contracts/0.4.24/oracle/LegacyOracle.sol
@@ -25,7 +25,8 @@ interface IHashConsensus {
 
     function getFrameConfig() external view returns (
         uint256 initialEpoch,
-        uint256 epochsPerFrame
+        uint256 epochsPerFrame,
+        uint256 fastLaneLengthSlots
     );
 
     function getCurrentFrame() external view returns (
@@ -147,7 +148,7 @@ contract LegacyOracle is Versioned, AragonApp {
             uint64 genesisTime
         )
     {
-        (, uint256 epochsPerFrame_) = _getAccountingConsensusContract().getFrameConfig();
+        (, uint256 epochsPerFrame_,) = _getAccountingConsensusContract().getFrameConfig();
         epochsPerFrame = uint64(epochsPerFrame_);
 
         ChainSpec memory spec = _getChainSpec();
@@ -365,7 +366,7 @@ contract LegacyOracle is Versioned, AragonApp {
     {
         IHashConsensus consensus = IHashConsensus(_accountingOracleConsensusContract);
         (uint256 slotsPerEpoch, uint256 secondsPerSlot, uint256 genesisTime) = consensus.getChainConfig();
-        (, uint256 epochsPerFrame_) = consensus.getFrameConfig();
+        (, uint256 epochsPerFrame_,) = consensus.getFrameConfig();
 
         spec.epochsPerFrame = uint64(epochsPerFrame_);
         spec.slotsPerEpoch = uint64(slotsPerEpoch);

--- a/contracts/0.8.9/oracle/AccountingOracle.sol
+++ b/contracts/0.8.9/oracle/AccountingOracle.sol
@@ -495,7 +495,7 @@ contract AccountingOracle is BaseOracle {
         internal view returns (uint256)
     {
         (uint256 initialEpoch,
-            uint256 epochsPerFrame) = IConsensusContract(consensusContract).getFrameConfig();
+            uint256 epochsPerFrame,) = IConsensusContract(consensusContract).getFrameConfig();
 
         (uint256 slotsPerEpoch,
             uint256 secondsPerSlot,

--- a/contracts/0.8.9/oracle/BaseOracle.sol
+++ b/contracts/0.8.9/oracle/BaseOracle.sol
@@ -25,7 +25,11 @@ interface IConsensusContract {
         uint256 genesisTime
     );
 
-    function getFrameConfig() external view returns (uint256 initialEpoch, uint256 epochsPerFrame);
+    function getFrameConfig() external view returns (
+        uint256 initialEpoch,
+        uint256 epochsPerFrame,
+        uint256 fastLaneLengthSlots
+    );
 
     function getInitialRefSlot() external view returns (uint256);
 }

--- a/test/0.4.24/contracts/HashConsensus__MockForLegacyOracle.sol
+++ b/test/0.4.24/contracts/HashConsensus__MockForLegacyOracle.sol
@@ -80,10 +80,11 @@ contract HashConsensus__MockForLegacyOracle is IHashConsensus {
 
     function getFrameConfig() external view returns (
         uint256 initialEpoch,
-        uint256 epochsPerFrame
+        uint256 epochsPerFrame,
+        uint256 fastLaneLengthSlots
     ) {
         FrameConfig memory config = _frameConfig;
-        return (config.initialEpoch, config.epochsPerFrame);
+        return (config.initialEpoch, config.epochsPerFrame, config.fastLaneLengthSlots);
     }
 
     function getCurrentFrame() external view returns (

--- a/test/0.8.9/contracts/MockConsensusContract.sol
+++ b/test/0.8.9/contracts/MockConsensusContract.sol
@@ -104,9 +104,9 @@ contract MockConsensusContract is IConsensusContract {
     function getFrameConfig()
         external
         view
-        returns (uint256 initialEpoch, uint256 epochsPerFrame)
+        returns (uint256 initialEpoch, uint256 epochsPerFrame, uint256 fastLaneLengthSlots)
     {
-        return (_frameConfig.initialEpoch, _frameConfig.epochsPerFrame);
+        return (_frameConfig.initialEpoch, _frameConfig.epochsPerFrame, _frameConfig.fastLaneLengthSlots);
     }
 
     function getInitialRefSlot() external view returns (uint256) {


### PR DESCRIPTION
### PR Summary:
This PR highlights a minor discrepancy between the `getFrameConfig` method signature in the `HashConsensus` contract and its corresponding interface definition used in other contracts.

Below is the `getFrameConfig` method from the `HashConsensus` contract:
```solidity
contract HashConsensus
    function getFrameConfig() external view returns (
        uint256 initialEpoch,
        uint256 epochsPerFrame,
        uint256 fastLaneLengthSlots
    ) {
        FrameConfig memory config = _frameConfig;
        return (config.initialEpoch, config.epochsPerFrame, config.fastLaneLengthSlots);
    }
}
```
And here is an example of an interface definition in contracts that use this method, where the `fastLaneLengthSlots` field is not included in the interface:
```solidity
interface IConsensusContract {
    function getFrameConfig() external view returns (
        uint256 initialEpoch, 
        uint256 epochsPerFrame
    );
}
```

### Background:
The fastLaneLengthSlots parameter was introduced in this [commit](https://github.com/lidofinance/core/commit/a5a9bad703428e86d5bd652b825e43ff5462c374). However, the interface was not updated for the following reasons:

Backward Compatibility: If the HashConsensus is updated to return additional values (such as fastLaneLengthSlots), existing contracts that rely on the IConsensusContract interface do not need to be modified, as long as they are only interested in the first two return values (initialEpoch and epochsPerFrame). The additional value (fastLaneLengthSlots) will be ignored by contracts not expecting it.

Selective Data Retrieval: In some cases, contracts interacting with HashConsensus only require specific values (e.g., initialEpoch and epochsPerFrame). Using an interface with fewer return values simplifies the interaction. This approach avoids the need to handle or store unused data, potentially reducing gas costs and keeping the code cleaner.

---

Ported from https://github.com/lidofinance/core-ex-repovation/pull/210