### PR TITLE
fix: remove PostTotalShares event checks

### DIFF
--- a/test/integration/accounting.integration.ts
+++ b/test/integration/accounting.integration.ts
@@ -205,11 +205,6 @@ describe("Accounting", () => {
     const { sharesRateBefore, sharesRateAfter } = shareRateFromEvent(tokenRebasedEvent[0]);
     expect(sharesRateBefore).to.be.lessThanOrEqual(sharesRateAfter);
 
-    const postTotalSharesEvent = ctx.getEvents(reportTxReceipt, "PostTotalShares");
-    expect(postTotalSharesEvent[0].args.preTotalPooledEther).to.equal(
-      postTotalSharesEvent[0].args.postTotalPooledEther + amountOfETHLocked,
-    );
-
     const ethBalanceAfter = await ethers.provider.getBalance(lido.address);
     expect(ethBalanceBefore).to.equal(ethBalanceAfter + amountOfETHLocked);
   });
@@ -257,12 +252,6 @@ describe("Accounting", () => {
     expect(ethDistributedEvent[0].args.preCLBalance + REBASE_AMOUNT).to.equal(
       ethDistributedEvent[0].args.postCLBalance,
       "ETHDistributed: CL balance differs from expected",
-    );
-
-    const postTotalSharesEvent = ctx.getEvents(reportTxReceipt, "PostTotalShares");
-    expect(postTotalSharesEvent[0].args.preTotalPooledEther + REBASE_AMOUNT).to.equal(
-      postTotalSharesEvent[0].args.postTotalPooledEther + amountOfETHLocked,
-      "PostTotalShares: TotalPooledEther differs from expected",
     );
   });
 
@@ -379,12 +368,6 @@ describe("Accounting", () => {
     expect(ethDistributedEvent[0].args.preCLBalance + rebaseAmount).to.equal(
       ethDistributedEvent[0].args.postCLBalance,
       "ETHDistributed: CL balance has not increased",
-    );
-
-    const postTotalSharesEvent = ctx.getEvents(reportTxReceipt, "PostTotalShares");
-    expect(postTotalSharesEvent[0].args.preTotalPooledEther + rebaseAmount).to.equal(
-      postTotalSharesEvent[0].args.postTotalPooledEther + amountOfETHLocked,
-      "PostTotalShares: TotalPooledEther has not increased",
     );
   });
 


### PR DESCRIPTION
## Context

The `PostTotalShares` event has been turned down during https://vote.lido.fi/vote/179 enact. Need to adjust tests.

## Problem

No event, so those checks are not possible now. This is an intentional change.

## Solution

Remove the checks
