### PR TITLE
fix: get rid of double division on shares to eth conversion

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -196,7 +196,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      * @param _eip712StETH eip712 helper contract for StETH
      */
     function initialize(address _lidoLocator, address _eip712StETH) public payable onlyInit {
-        _bootstrapInitialHolder();
+        _bootstrapInitialHolder(); // stone in the elevator
 
         LIDO_LOCATOR_POSITION.setStorageAddress(_lidoLocator);
         emit LidoLocatorSet(_lidoLocator);
@@ -958,7 +958,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
     /// @dev the denominator (in shares) of the share rate for StETH conversion between shares and ether and vice versa.
     function _getShareRateDenominator() internal view returns (uint256) {
         uint256 externalShares = EXTERNAL_SHARES_POSITION.getStorageUint256();
-        uint256 internalShares = _getTotalShares() - externalShares;
+        uint256 internalShares = _getTotalShares() - externalShares; // never 0 because of the stone in the elevator
         return internalShares;
     }
 

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -947,6 +947,21 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         return internalEther.add(_getExternalEther(internalEther));
     }
 
+    /// @dev the numerator (in ether) of the share rate for StETH conversion between shares and ether and vice versa.
+    /// using the numerator and denominator different from totalShares and totalPooledEther allows to:
+    /// - avoid double precision loss on additional division on external ether calculations
+    /// - optimize gas cost of conversions between shares and ether
+    function _getShareRateNumerator() internal view returns (uint256) {
+        return _getInternalEther();
+    }
+
+    /// @dev the denominator (in shares) of the share rate for StETH conversion between shares and ether and vice versa.
+    function _getShareRateDenominator() internal view returns (uint256) {
+        uint256 externalShares = EXTERNAL_SHARES_POSITION.getStorageUint256();
+        uint256 internalShares = _getTotalShares() - externalShares;
+        return internalShares;
+    }
+
     /// @notice Calculate the maximum amount of external shares that can be minted while maintaining
     ///         maximum allowed external ratio limits
     /// @return Maximum amount of external shares that can be minted

--- a/contracts/0.4.24/StETH.sol
+++ b/contracts/0.4.24/StETH.sol
@@ -303,8 +303,8 @@ contract StETH is IERC20, Pausable {
      */
     function getSharesByPooledEth(uint256 _ethAmount) public view returns (uint256) {
         return _ethAmount
-            .mul(_getTotalShares())
-            .div(_getTotalPooledEther());
+            .mul(_getShareRateDenominator()) // denominator in shares
+            .div(_getShareRateNumerator()); // numerator in ether
     }
 
     /**
@@ -312,8 +312,8 @@ contract StETH is IERC20, Pausable {
      */
     function getPooledEthByShares(uint256 _sharesAmount) public view returns (uint256) {
         return _sharesAmount
-            .mul(_getTotalPooledEther())
-            .div(_getTotalShares());
+            .mul(_getShareRateNumerator()) // numerator in ether
+            .div(_getShareRateDenominator()); // denominator in shares
     }
 
     /**
@@ -322,14 +322,14 @@ contract StETH is IERC20, Pausable {
      *  for `shareRate >= 0.5`, `getSharesByPooledEth(getPooledEthBySharesRoundUp(1))` will be 1.
      */
     function getPooledEthBySharesRoundUp(uint256 _sharesAmount) public view returns (uint256 etherAmount) {
-        uint256 totalEther = _getTotalPooledEther();
-        uint256 totalShares = _getTotalShares();
+        uint256 numeratorInEther = _getShareRateNumerator();
+        uint256 denominatorInShares = _getShareRateDenominator();
 
         etherAmount = _sharesAmount
-            .mul(totalEther)
-            .div(totalShares);
+            .mul(numeratorInEther)
+            .div(denominatorInShares);
 
-        if (etherAmount.mul(totalShares) != _sharesAmount.mul(totalEther)) {
+        if (_sharesAmount.mul(numeratorInEther) != etherAmount.mul(denominatorInShares)) {
             ++etherAmount;
         }
     }
@@ -388,6 +388,22 @@ contract StETH is IERC20, Pausable {
      * @dev This function is required to be implemented in a derived contract.
      */
     function _getTotalPooledEther() internal view returns (uint256);
+
+    /**
+     * @return the numerator of the protocol's share rate (in ether).
+     * @dev used to convert shares to tokens and vice versa.
+     */
+    function _getShareRateNumerator() internal view returns (uint256) {
+        return _getTotalPooledEther();
+    }
+
+    /**
+     * @return the denominator of the protocol's share rate (in shares).
+     * @dev used to convert shares to tokens and vice versa.
+     */
+    function _getShareRateDenominator() internal view returns (uint256) {
+        return _getTotalShares();
+    }
 
     /**
      * @notice Moves `_amount` tokens from `_sender` to `_recipient`.

--- a/test/0.4.24/lido/lido.externalShares.test.ts
+++ b/test/0.4.24/lido/lido.externalShares.test.ts
@@ -46,12 +46,12 @@ describe("Lido.sol:externalShares", () => {
     accountingSigner = await impersonate(await locator.accounting(), ether("1"));
 
     // Add some ether to the protocol
-    await lido.connect(whale).submit(ZeroAddress, { value: 1000n });
+    await lido.connect(whale).submit(ZeroAddress, { value: ether("1000") });
 
     // Burn some shares to make share rate fractional
     const burner = await impersonate(await locator.burner(), ether("1"));
-    await lido.connect(whale).transfer(burner, 500n);
-    await lido.connect(burner).burnShares(500n);
+    await lido.connect(whale).transfer(burner, ether("500"));
+    await lido.connect(burner).burnShares(ether("500"));
   });
 
   beforeEach(async () => (originalState = await Snapshot.take()));
@@ -199,16 +199,16 @@ describe("Lido.sol:externalShares", () => {
       // Increase the external ether limit to 10%
       await lido.setMaxExternalRatioBP(maxExternalRatioBP);
 
-      const amountToMint = await lido.getMaxMintableExternalShares();
-      const etherToMint = await lido.getPooledEthByShares(amountToMint);
+      const sharesToMint = 1n;
+      const etherToMint = await lido.getPooledEthByShares(sharesToMint);
 
-      await expect(lido.connect(accountingSigner).mintExternalShares(whale, amountToMint))
+      await expect(lido.connect(accountingSigner).mintExternalShares(whale, sharesToMint))
         .to.emit(lido, "Transfer")
         .withArgs(ZeroAddress, whale, etherToMint)
         .to.emit(lido, "TransferShares")
-        .withArgs(ZeroAddress, whale, amountToMint)
+        .withArgs(ZeroAddress, whale, sharesToMint)
         .to.emit(lido, "ExternalSharesMinted")
-        .withArgs(whale, amountToMint, etherToMint);
+        .withArgs(whale, sharesToMint, etherToMint);
 
       // Verify external balance was increased
       const externalEther = await lido.getExternalEther();
@@ -280,11 +280,11 @@ describe("Lido.sol:externalShares", () => {
 
       // Burn partial amount
       await lido.connect(accountingSigner).burnExternalShares(150n);
-      expect(await lido.getExternalEther()).to.equal(150n);
+      expect(await lido.getExternalShares()).to.equal(150n);
 
       // Burn remaining
       await lido.connect(accountingSigner).burnExternalShares(150n);
-      expect(await lido.getExternalEther()).to.equal(0n);
+      expect(await lido.getExternalShares()).to.equal(0n);
     });
   });
 


### PR DESCRIPTION
External shares concept introduce double division during the shares to eth conversion calculations and vise versa. 

The suggested way to fix it is to use internal ether and internal shares for conversion in `getPooledEthForShares()` and `getSharesForPoooledEther()` 
