### PR TITLE
fix: refactor hardhat config file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ MAINNET_RPC_URL=http://localhost:8545
 
 # RPC URL for Hardhat Network forking, required for running tests on mainnet fork with tracing (Infura, Alchemy, etc.)
 # https://hardhat.org/hardhat-network/docs/guides/forking-other-networks#forking-other-networks
-HARDHAT_FORKING_URL=
+HARDHAT_FORKING_URL=https://eth.drpc.org
 
 # https://docs.lido.fi/deployed-contracts
 MAINNET_LOCATOR_ADDRESS=0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,7 +328,7 @@ mainnet environment, allowing you to run integration tests with trace logging.
 
 > [!NOTE]
 > Ensure that `HARDHAT_FORKING_URL` is set to Ethereum Mainnet RPC and `MAINNET_*` environment variables are set in the
-> `.env` file (refer to `.env.example` for guidance).
+> `.env` file (refer to `.env.example` for guidance). Otherwise, the tests will run against the Scratch deployment.
 
 ```bash
 # Run all integration tests

--- a/hardhat.helpers.ts
+++ b/hardhat.helpers.ts
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync } from "node:fs";
+
+/* Determines the forking configuration for Hardhat */
+export function getHardhatForkingConfig() {
+  const forkingUrl = process.env.HARDHAT_FORKING_URL || "";
+
+  if (!forkingUrl) {
+    // Scratch deploy, need to disable CSM
+    process.env.INTEGRATION_ON_SCRATCH = "on";
+    process.env.INTEGRATION_WITH_CSM = "off";
+    return undefined;
+  }
+
+  return { url: forkingUrl };
+}
+
+// TODO: this plaintext accounts.json private keys management is a subject
+//       of rework to a solution with the keys stored encrypted
+export function loadAccounts(networkName: string) {
+  const accountsPath = "./accounts.json";
+
+  if (!existsSync(accountsPath)) {
+    return [];
+  }
+
+  const content = JSON.parse(readFileSync(accountsPath, "utf-8"));
+  if (!content.eth) {
+    return [];
+  }
+
+  return content.eth[networkName] || [];
+}

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -1,2 +1,3 @@
 export * from "./verify-contracts";
 export * from "./extract-abis";
+export * from "./solidity-get-source";

--- a/tasks/solidity-get-source.ts
+++ b/tasks/solidity-get-source.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+
+import { globSync } from "glob";
+import { TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS } from "hardhat/builtin-tasks/task-names";
+import { subtask } from "hardhat/config";
+
+// a workaround for having an additional source directory for compilation
+// see, https://github.com/NomicFoundation/hardhat/issues/776#issuecomment-1713584386
+
+subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(async (_, hre, runSuper) => {
+  const paths = await runSuper();
+
+  const otherDirectoryGlob = path.join(hre.config.paths.root, "test", "**", "*.sol");
+  // Don't need to compile test, helper and script files that are not part of the contracts for Hardhat.
+  const otherPaths = globSync(otherDirectoryGlob).filter((x) => !/\.([ths]\.sol)$/.test(x));
+
+  return [...paths, ...otherPaths];
+});


### PR DESCRIPTION
Update default hardhat settings to avoid inconsistent tests.

## Problem

Currently running `test:integration` without setting `HARDHAT_FORKING_URL` leads to testing on Scratch deployment, but with mainnet config. This PR solves this issue.