### PR TITLE
feat: override withdrawableEther in Delegation contract

### DIFF
--- a/contracts/0.8.25/vaults/Dashboard.sol
+++ b/contracts/0.8.25/vaults/Dashboard.sol
@@ -192,7 +192,7 @@ contract Dashboard is Permissions {
      * @notice Returns the amount of ether that can be withdrawn from the staking vault.
      * @return The amount of ether that can be withdrawn.
      */
-    function withdrawableEther() external view returns (uint256) {
+    function withdrawableEther() external view virtual returns (uint256) {
         return Math256.min(address(stakingVault()).balance, stakingVault().unlocked());
     }
 

--- a/contracts/0.8.25/vaults/Delegation.sol
+++ b/contracts/0.8.25/vaults/Delegation.sol
@@ -4,6 +4,8 @@
 // See contracts/COMPILERS.md
 pragma solidity 0.8.25;
 
+import {Math256} from "contracts/common/lib/Math256.sol";
+
 import {IStakingVault} from "./interfaces/IStakingVault.sol";
 import {Dashboard} from "./Dashboard.sol";
 
@@ -149,6 +151,16 @@ contract Delegation is Dashboard {
         uint256 valuation = stakingVault().valuation();
 
         return reserved > valuation ? 0 : valuation - reserved;
+    }
+
+    /**
+     * @notice Returns the amount of ether that can be withdrawn from the staking vault.
+     * @dev This is the amount of ether that is not locked in the StakingVault and not reserved for curator and node operator fees.
+     * @dev This method overrides the Dashboard's withdrawableEther() method
+     * @return The amount of ether that can be withdrawn.
+     */
+    function withdrawableEther() external view override returns (uint256) {
+        return Math256.min(address(stakingVault()).balance, unreserved());
     }
 
     /**

--- a/test/0.8.25/vaults/delegation/delegation.test.ts
+++ b/test/0.8.25/vaults/delegation/delegation.test.ts
@@ -362,6 +362,45 @@ describe("Delegation.sol", () => {
     });
   });
 
+  context("withdrawableEther", () => {
+    it("returns the correct amount", async () => {
+      const amount = ether("1");
+      await delegation.connect(funder).fund({ value: amount });
+      expect(await delegation.withdrawableEther()).to.equal(amount);
+    });
+
+    it("returns the correct amount when balance is less than unreserved", async () => {
+      const valuation = ether("3");
+      const inOutDelta = 0n;
+      const locked = ether("2");
+
+      const amount = ether("1");
+      await delegation.connect(funder).fund({ value: amount });
+      await vault.connect(hubSigner).report(valuation, inOutDelta, locked);
+
+      expect(await delegation.withdrawableEther()).to.equal(amount);
+    });
+
+    it("returns the correct amount when has fees", async () => {
+      const amount = ether("6");
+      const valuation = ether("3");
+      const inOutDelta = ether("1");
+      const locked = ether("2");
+
+      const curatorFeeBP = 1000; // 10%
+      const operatorFeeBP = 1000; // 10%
+      await delegation.connect(vaultOwner).setCuratorFeeBP(curatorFeeBP);
+      await delegation.connect(nodeOperatorManager).setNodeOperatorFeeBP(operatorFeeBP);
+
+      await delegation.connect(funder).fund({ value: amount });
+
+      await vault.connect(hubSigner).report(valuation, inOutDelta, locked);
+      const unreserved = await delegation.unreserved();
+
+      expect(await delegation.withdrawableEther()).to.equal(unreserved);
+    });
+  });
+
   context("fund", () => {
     it("reverts if the caller is not a member of the staker role", async () => {
       await expect(delegation.connect(stranger).fund()).to.be.revertedWithCustomError(


### PR DESCRIPTION
A short summary of the changes.

## Context

Enhancements to `withdrawableEther` method:

* [`contracts/0.8.25/vaults/Dashboard.sol`](diffhunk://#diff-cbeb97ef6515a935b3e6e79462853127710f57336b9cdb25d13be32ae6a040d6L195-R195): Made the `withdrawableEther` method virtual to allow overriding in derived contracts.
* [`contracts/0.8.25/vaults/Delegation.sol`](diffhunk://#diff-0823ff08c8e75ba30a3b212797cca8c3a37ef377b47288271d750c207e24b556R156-R165): Added an override for the `withdrawableEther` method to account for unreserved ether.

Code imports:

* [`contracts/0.8.25/vaults/Delegation.sol`](diffhunk://#diff-0823ff08c8e75ba30a3b212797cca8c3a37ef377b47288271d750c207e24b556R7-R8): Imported `Math256` library for mathematical operations.

Testing improvements:

* [`test/0.8.25/vaults/delegation/delegation.test.ts`](diffhunk://#diff-ba8e1b568d2a066f26120d09f7e9e9ff6e31fe7c192f687ba7838ac30ea5fc25R365-R403): Added tests for the `withdrawableEther` method to ensure it returns the correct amount under various conditions.


