### PR TITLE
chore: migrate foundry to stable

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,7 @@ test = 'test'
 cache = true
 
 # The cache directory if enabled
-cache_path  = 'foundry/cache'
+cache_path = 'foundry/cache'
 
 # Only run tests in contracts matching the specified glob pattern
 match_path = '**/test/**/*.t.sol'

--- a/test/common/memUtils.t.sol
+++ b/test/common/memUtils.t.sol
@@ -483,6 +483,7 @@ contract MemUtilsTest is Test, MemUtilsTestHelper {
         assertEq(dst, abi.encodePacked(bytes32(0x2211111111111111111111111111111111111111111111111111111111111111)));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_copyBytes_RevertsWhenSrcArrayIsOutOfBounds() external {
         bytes memory src = abi.encodePacked(
             bytes32(0x1111111111111111111111111111111111111111111111111111111111111111)


### PR DESCRIPTION
Migrate foundry to 1.0 (https://book.getfoundry.sh/guides/v1.0-migration)