### PR TITLE
feat: update vault filtering and methods, tests

### DIFF
--- a/test/0.8.25/vaults/vault-hub-viewer/contracts/VaultHub__MockForHubViewer.sol
+++ b/test/0.8.25/vaults/vault-hub-viewer/contracts/VaultHub__MockForHubViewer.sol
@@ -40,6 +40,10 @@ contract VaultHub__MockForHubViewer {
         return vaultSockets[_vault];
     }
 
+    function vaultSocket(uint256 _index) external view returns (VaultHub.VaultSocket memory) {
+        return _getVaultHubStorage().sockets[_index];
+    }
+
     function vaultSocketIndex(address _vault) public view returns (uint256) {
         return _getVaultHubStorage().vaultIndex[_vault];
     }


### PR DESCRIPTION
A short summary of the changes.

## Context

### Refactoring and Code Cleanup:
* Removed the `VaultSocket` struct and `IVaultHub` interface from `VaultHubViewerV1.sol` and replaced their usage with the `VaultHub` contract. [[1]](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289L18-R27) [[2]](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289L191-R162) [[3]](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289L206-R178) [[4]](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289L227-R198)
* Added the `VaultHub` import in `VaultHubViewerV1.sol`.

### Test Case Updates:
* Updated the `deployVaultDelegation` and `deployVaultDashboard` functions in `vault-hub-viewer.ts` to include `manager` and `operator` parameters and removed unnecessary comments. [[1]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L27-R46) [[2]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L74-L75) [[3]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L103-L112)
* Refactored `describe("VaultHubViewerV1", () => {` in `vault-hub-viewer.ts` to include new test cases for `vaultsConnected`, `vaultsConnectedBound`, `vaultsByOwnerBound`, and `vaultsByRoleBound`. [[1]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L217-R203) [[2]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L264-R277) [[3]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L306-R355) [[4]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741R366-R386)

### Mock Contract Changes:
* Added a new `vaultSocket` function to the `VaultHub__MockForHubViewer` mock contract to return `VaultHub.VaultSocket`.

