### PR TITLE
Fix/hub viewer filtering

### DIFF
--- a/contracts/0.8.25/vaults/VaultHubViewerV1.sol
+++ b/contracts/0.8.25/vaults/VaultHubViewerV1.sol
@@ -227,10 +227,12 @@ contract VaultHubViewerV1 {
         uint256 _from,
         uint256 _to
     ) internal pure returns (IVault[] memory filtered) {
+        if (_to < _from) revert WrongPaginationRange(_from, _to);
+
         uint256 count = _to - _from;
         filtered = new IVault[](count);
-        for (uint256 i = _from; i < count; i++) {
-            filtered[i] = _vaults[i];
+        for (uint256 i = 0; i < count; i++) {
+            filtered[i] = _vaults[_from + i];
         }
     }
 
@@ -239,4 +241,9 @@ contract VaultHubViewerV1 {
     /// @notice Error for zero address arguments
     /// @param argName Name of the argument that is zero
     error ZeroArgument(string argName);
+
+    /// @notice Error for wrong pagination range
+    /// @param _from Start of the range
+    /// @param _to End of the range
+    error WrongPaginationRange(uint256 _from, uint256 _to);
 }

--- a/contracts/0.8.25/vaults/VaultHubViewerV1.sol
+++ b/contracts/0.8.25/vaults/VaultHubViewerV1.sol
@@ -153,6 +153,7 @@ contract VaultHubViewerV1 {
 
     /// @dev common logic for vaultsConnected and vaultsConnectedBound
     function _vaultsConnected() internal view returns (IVault[] memory, uint256) {
+        // TODO: get vaults by pages, not all vaults
         uint256 count = vaultHub.vaultsCount();
         IVault[] memory vaults = new IVault[](count);
 
@@ -169,6 +170,7 @@ contract VaultHubViewerV1 {
 
     /// @dev common logic for vaultsByRole and vaultsByRoleBound
     function _vaultsByRole(bytes32 _role, address _member) internal view returns (IVault[] memory, uint256) {
+        // TODO: get vaults by pages, not all vaults
         uint256 count = vaultHub.vaultsCount();
         IVault[] memory vaults = new IVault[](count);
 
@@ -185,6 +187,7 @@ contract VaultHubViewerV1 {
 
     /// @dev common logic for vaultsByOwner and vaultsByOwnerBound
     function _vaultsByOwner(address _owner) internal view returns (IVault[] memory, uint256) {
+        // TODO: get vaults by pages, not all vaults
         uint256 count = vaultHub.vaultsCount();
         IVault[] memory vaults = new IVault[](count);
 

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -272,7 +272,10 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("reverts if from is greater than to", async () => {
-      await expect(vaultHubViewer.vaultsConnectedBound(3, 1)).to.be.revertedWithPanic();
+      await expect(vaultHubViewer.vaultsConnectedBound(3, 1)).to.be.revertedWithCustomError(
+        vaultHubViewer,
+        "WrongPaginationRange",
+      );
     });
   });
 
@@ -323,7 +326,10 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("reverts if from is greater than to", async () => {
-      await expect(vaultHubViewer.vaultsByOwnerBound(vaultOwner.getAddress(), 3, 1)).to.be.revertedWithPanic();
+      await expect(vaultHubViewer.vaultsByOwnerBound(vaultOwner.getAddress(), 3, 1)).to.be.revertedWithCustomError(
+        vaultHubViewer,
+        "WrongPaginationRange",
+      );
     });
   });
 


### PR DESCRIPTION
A short summary of the changes.

## Context

Improvements to pagination handling:

* [`contracts/0.8.25/vaults/VaultHubViewerV1.sol`](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289R156): Added a new error `WrongPaginationRange` for incorrect pagination ranges and updated the `_vaultsConnected`, `_vaultsByRole`, and `_vaultsByOwner` functions with TODO comments to implement pagination in the future. [[1]](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289R156) [[2]](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289R173) [[3]](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289R190) [[4]](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289R247-R251)

Error handling improvements:

* [`contracts/0.8.25/vaults/VaultHubViewerV1.sol`](diffhunk://#diff-174bcb9398f252ced80fd0caadc0411e7c49cfaa5589a458563542044c484289R233-R238): Added a check in the `filteredVaults` function to revert with `WrongPaginationRange` if the `_to` parameter is less than the `_from` parameter.

Test updates:

* [`test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts`](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L275-R278): Updated test cases to check for the `WrongPaginationRange` error instead of a generic panic error when the pagination range is incorrect. [[1]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L275-R278) [[2]](diffhunk://#diff-3bd2f29483f587743f349f4d46da68271a904ac2725d9ac49b7f393411a27741L326-R332)

