### PR TITLE
fix(VaultHub): rename mint/burn

### DIFF
--- a/contracts/0.8.25/vaults/Permissions.sol
+++ b/contracts/0.8.25/vaults/Permissions.sol
@@ -181,7 +181,7 @@ abstract contract Permissions is AccessControlConfirmable {
      * @dev The zero checks for parameters are performed in the VaultHub contract.
      */
     function _mintShares(address _recipient, uint256 _shares) internal onlyRole(MINT_ROLE) {
-        vaultHub.mintSharesBackedByVault(address(stakingVault()), _recipient, _shares);
+        vaultHub.mintShares(address(stakingVault()), _recipient, _shares);
     }
 
     /**
@@ -190,7 +190,7 @@ abstract contract Permissions is AccessControlConfirmable {
      * @dev The zero check for parameters is performed in the VaultHub contract.
      */
     function _burnShares(uint256 _shares) internal onlyRole(BURN_ROLE) {
-        vaultHub.burnSharesBackedByVault(address(stakingVault()), _shares);
+        vaultHub.burnShares(address(stakingVault()), _shares);
     }
 
     /**

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -213,7 +213,7 @@ abstract contract VaultHub is PausableUntilWithRoles {
     /// @param _recipient address of the receiver
     /// @param _amountOfShares amount of stETH shares to mint
     /// @dev msg.sender should be vault's owner
-    function mintSharesBackedByVault(address _vault, address _recipient, uint256 _amountOfShares) external whenResumed {
+    function mintShares(address _vault, address _recipient, uint256 _amountOfShares) external whenResumed {
         if (_vault == address(0)) revert ZeroArgument("_vault");
         if (_recipient == address(0)) revert ZeroArgument("_recipient");
         if (_amountOfShares == 0) revert ZeroArgument("_amountOfShares");
@@ -252,7 +252,7 @@ abstract contract VaultHub is PausableUntilWithRoles {
     /// @param _amountOfShares amount of shares to burn
     /// @dev msg.sender should be vault's owner
     /// @dev VaultHub must have all the stETH on its balance
-    function burnSharesBackedByVault(address _vault, uint256 _amountOfShares) public whenResumed {
+    function burnShares(address _vault, uint256 _amountOfShares) public whenResumed {
         if (_vault == address(0)) revert ZeroArgument("_vault");
         if (_amountOfShares == 0) revert ZeroArgument("_amountOfShares");
         _vaultAuth(_vault, "burn");
@@ -271,10 +271,10 @@ abstract contract VaultHub is PausableUntilWithRoles {
 
     /// @notice separate burn function for EOA vault owners; requires vaultHub to be approved to transfer stETH
     /// @dev msg.sender should be vault's owner
-    function transferAndBurnSharesBackedByVault(address _vault, uint256 _amountOfShares) external {
+    function transferAndBurnShares(address _vault, uint256 _amountOfShares) external {
         STETH.transferSharesFrom(msg.sender, address(this), _amountOfShares);
 
-        burnSharesBackedByVault(_vault, _amountOfShares);
+        burnShares(_vault, _amountOfShares);
     }
 
     /// @notice force rebalance of the vault to have sufficient reserve ratio

--- a/test/0.8.25/vaults/contracts/VaultHub__MockForVault.sol
+++ b/test/0.8.25/vaults/contracts/VaultHub__MockForVault.sol
@@ -4,9 +4,9 @@
 pragma solidity 0.8.25;
 
 contract VaultHub__MockForVault {
-    function mintSharesBackedByVault(address _recipient, uint256 _amountOfShares) external returns (uint256 locked) {}
+    function mintShares(address _recipient, uint256 _amountOfShares) external returns (uint256 locked) {}
 
-    function burnSharesBackedByVault(uint256 _amountOfShares) external {}
+    function burnShares(uint256 _amountOfShares) external {}
 
     function rebalance() external payable {}
 }

--- a/test/0.8.25/vaults/dashboard/contracts/VaultHub__MockForDashboard.sol
+++ b/test/0.8.25/vaults/dashboard/contracts/VaultHub__MockForDashboard.sol
@@ -41,7 +41,7 @@ contract VaultHub__MockForDashboard {
         emit Mock__VaultDisconnected(vault);
     }
 
-    function mintSharesBackedByVault(address vault, address recipient, uint256 amount) external {
+    function mintShares(address vault, address recipient, uint256 amount) external {
         if (vault == address(0)) revert ZeroArgument("_vault");
         if (recipient == address(0)) revert ZeroArgument("recipient");
         if (amount == 0) revert ZeroArgument("amount");
@@ -50,7 +50,7 @@ contract VaultHub__MockForDashboard {
         vaultSockets[vault].sharesMinted = uint96(vaultSockets[vault].sharesMinted + amount);
     }
 
-    function burnSharesBackedByVault(address _vault, uint256 _amountOfShares) external {
+    function burnShares(address _vault, uint256 _amountOfShares) external {
         if (_vault == address(0)) revert ZeroArgument("_vault");
         if (_amountOfShares == 0) revert ZeroArgument("_amountOfShares");
         steth.burnExternalShares(_amountOfShares);

--- a/test/0.8.25/vaults/delegation/contracts/VaultHub__MockForDelegation.sol
+++ b/test/0.8.25/vaults/delegation/contracts/VaultHub__MockForDelegation.sol
@@ -20,11 +20,11 @@ contract VaultHub__MockForDelegation {
         emit Mock__VaultDisconnected(vault);
     }
 
-    function mintSharesBackedByVault(address /* vault */, address recipient, uint256 amount) external {
+    function mintShares(address /* vault */, address recipient, uint256 amount) external {
         steth.mint(recipient, amount);
     }
 
-    function burnSharesBackedByVault(address /* vault */, uint256 amount) external {
+    function burnShares(address /* vault */, uint256 amount) external {
         steth.burn(amount);
     }
 

--- a/test/0.8.25/vaults/permissions/contracts/VaultHub__MockPermissions.sol
+++ b/test/0.8.25/vaults/permissions/contracts/VaultHub__MockPermissions.sol
@@ -9,11 +9,11 @@ contract VaultHub__MockPermissions {
     event Mock__Rebalanced(uint256 _ether);
     event Mock__VoluntaryDisconnect(address indexed _stakingVault);
 
-    function mintSharesBackedByVault(address _stakingVault, address _recipient, uint256 _shares) external {
+    function mintShares(address _stakingVault, address _recipient, uint256 _shares) external {
         emit Mock__SharesMinted(_stakingVault, _recipient, _shares);
     }
 
-    function burnSharesBackedByVault(address _stakingVault, uint256 _shares) external {
+    function burnShares(address _stakingVault, uint256 _shares) external {
         emit Mock__SharesBurned(_stakingVault, _shares);
     }
 

--- a/test/0.8.25/vaults/vaulthub/vaulthub.pausable.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.pausable.test.ts
@@ -157,28 +157,25 @@ describe("VaultHub.sol:pausableUntil", () => {
       await expect(vaultHub.voluntaryDisconnect(user)).to.be.revertedWithCustomError(vaultHub, "ResumedExpected");
     });
 
-    it("reverts mintSharesBackedByVault() if paused", async () => {
-      await expect(vaultHub.mintSharesBackedByVault(stranger, user, 1000n)).to.be.revertedWithCustomError(
+    it("reverts mintShares() if paused", async () => {
+      await expect(vaultHub.mintShares(stranger, user, 1000n)).to.be.revertedWithCustomError(
         vaultHub,
         "ResumedExpected",
       );
     });
 
-    it("reverts burnSharesBackedByVault() if paused", async () => {
-      await expect(vaultHub.burnSharesBackedByVault(stranger, 1000n)).to.be.revertedWithCustomError(
-        vaultHub,
-        "ResumedExpected",
-      );
+    it("reverts burnShares() if paused", async () => {
+      await expect(vaultHub.burnShares(stranger, 1000n)).to.be.revertedWithCustomError(vaultHub, "ResumedExpected");
     });
 
     it("reverts rebalance() if paused", async () => {
       await expect(vaultHub.rebalance()).to.be.revertedWithCustomError(vaultHub, "ResumedExpected");
     });
 
-    it("reverts transferAndBurnSharesBackedByVault() if paused", async () => {
+    it("reverts transferAndBurnShares() if paused", async () => {
       await steth.connect(user).approve(vaultHub, 1000n);
 
-      await expect(vaultHub.transferAndBurnSharesBackedByVault(stranger, 1000n)).to.be.revertedWithCustomError(
+      await expect(vaultHub.transferAndBurnShares(stranger, 1000n)).to.be.revertedWithCustomError(
         vaultHub,
         "ResumedExpected",
       );


### PR DESCRIPTION
Renames `[mint/burn/transferAndBurn]sharesBackedByVault` to `[mint/burn/transferAndBurn]shares`.