### PR TITLE
Fix typos and consistency issues in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Users can deposit ether to the Lido smart contract and receive stETH tokens in r
 
 ## Bug Bounty
 
-Please refer to the [Lido Bug Bounry](/bugbounty.md).
+Please refer to the [Lido Bug Bounty](/bugbounty.md).
 
 ## Contributing
 

--- a/docs/scratch-deploy.md
+++ b/docs/scratch-deploy.md
@@ -102,7 +102,7 @@ mnemonic.
 
 Follow these steps for local deployment:
 
-1. Run `yarn install` (get sure repo dependencies are installed)
+1. Run `yarn install` (make sure repo dependencies are installed)
 2. Run the node on port 8555 (for the commands, see subsections below)
 3. Run the deploy script `bash scripts/dao-local-deploy.sh` from root repo directory
 4. Check out the deploy artifacts in `deployed-local.json`
@@ -121,9 +121,9 @@ anvil -p 8555 --mnemonic "test test test test test test test test test test test
 yarn hardhat node
 ```
 
-### Holešky Testnet Deployment
+### Holesky Testnet Deployment
 
-To do Holešky deployment, the following parameters must be set up via env variables:
+To do Holesky deployment, the following parameters must be set up via env variables:
 
 - `DEPLOYER`. The deployer address. The deployer must own its private key. To ensure proper operation, it should have an
   adequate amount of ether. The total deployment gas cost is approximately 120,000,000 gas, and this cost can vary based

--- a/docs/upgrade-deploy.md
+++ b/docs/upgrade-deploy.md
@@ -18,16 +18,16 @@ E. g. to deploy `LidoLocator` implementation with new addresses for `legacyOracl
 on Sepolia run
 
 ```shell
-legacyOracle=<PUT-YOU-VALUE> \
-postTokenRebaseReceiver=<PUT-YOU-VALUE> \
+legacyOracle=<PUT-YOUR-VALUE> \
+postTokenRebaseReceiver=<PUT-YOUR-VALUE> \
 GAS_MAX_FEE=100 GAS_PRIORITY_FEE=2 \
-DEPLOYER=<PUT-YOU-VALUE> \
-RPC_URL=<PUT-YOU-VALUE> \
+DEPLOYER=<PUT-YOUR-VALUE> \
+RPC_URL=<PUT-YOUR-VALUE> \
 STEPS_FILE=scripts/upgrade/steps.json \
 yarn hardhat --network sepolia run --no-compile scripts/utils/migrate.ts
 ```
 
-specifying require values under `<PUT-YOU-VALUE>`.
+specifying required values under `<PUT-YOUR-VALUE>`.
 
 Names of env variables specifying new addresses (e.g. `postTokenRebaseReceiver`) correspond to immutables names of
 `LidoLocator` contract.


### PR DESCRIPTION
README.md
Fixed typo in "Bug Bounty" reference:
Before: Lido Bug Bounry  (/bugbounty.md)
After: Lido Bug Bounty  (/bugbounty.md)
Reason: "Bounry" is a typo, the correct spelling is "Bounty".
2. docs/scratch-deploy.md
Fixed incorrect wording in installation instruction:

Before: Run yarn install (get sure repo dependencies are installed)
After: Run yarn install (make sure repo dependencies are installed)
Reason: "get sure" is grammatically incorrect; "make sure" is the correct phrase.
Standardized testnet name "Holesky":

Before: Holešky Testnet Deployment
After: Holesky Testnet Deployment
Reason: The correct testnet name is "Holesky" (without the special character "š"), which matches Ethereum's official naming.
3. docs/upgrade-deploy.md
Fixed incorrect placeholder spelling:

Before: DEPLOYER=<PUT-YOU-VALUE>
After: DEPLOYER=<PUT-YOUR-VALUE>
Before: RPC_URL=<PUT-YOU-VALUE>
After: RPC_URL=<PUT-YOUR-VALUE>
Reason: "YOU" was incorrect; "YOUR" is the correct word in this context.
Fixed typo in "required values" reference:

Before: specifying require values under <PUT-YOU-VALUE>.
After: specifying required values under <PUT-YOUR-VALUE>.
Reason: "require" is incorrect in this context; "required" is the grammatically correct word.
