### PR TITLE
Feat/hub viewer update pagination and tests

### DIFF
--- a/contracts/0.8.25/vaults/VaultHubViewerV1.sol
+++ b/contracts/0.8.25/vaults/VaultHubViewerV1.sol
@@ -177,13 +177,13 @@ contract VaultHubViewerV1 {
                 resultIndex++;
             }
 
-            if (resultIndex > _limit) {
+            if (resultIndex >= _limit) {
                 break;
             }
         }
 
         // It does not take into account that there may be disconnected volts
-        uint256 leftover = allVaultsCount - i;
+        uint256 leftover = i < allVaultsCount ? allVaultsCount - (i + 1) : 0;
         return (_filterNonZeroVaults(resultVaults, 0, resultIndex), leftover);
     }
 

--- a/contracts/0.8.25/vaults/VaultHubViewerV1.sol
+++ b/contracts/0.8.25/vaults/VaultHubViewerV1.sol
@@ -170,9 +170,9 @@ contract VaultHubViewerV1 {
                 }
             }
 
-//            if (resultIndex >= resultVaultsCount) {
-//                break;
-//            }
+            if (resultIndex >= resultVaultsCount) {
+                break;
+            }
         }
 
         // It does not take into account that there may be disconnected volts

--- a/contracts/0.8.25/vaults/VaultHubViewerV1.sol
+++ b/contracts/0.8.25/vaults/VaultHubViewerV1.sol
@@ -171,11 +171,10 @@ contract VaultHubViewerV1 {
         uint256 resultVaultsCount = _to - _from;
         IVault[] memory resultVaults = new IVault[](resultVaultsCount);
         uint256 resultIndex = 0;
-        uint256 skip = 0;
-
 
         uint256 allVaultsCount = vaultHub.vaultsCount();
-        for (uint256 i = 0; i < allVaultsCount; i++) {
+        uint256 i;
+        for (i = 0; i < allVaultsCount; i++) {
             if (!vaultHub.vaultSocket(i).isDisconnected) {
                 if (i >= _from && i < _to) {
                     resultVaults[resultIndex] = IVault(vaultHub.vault(i));
@@ -184,14 +183,13 @@ contract VaultHubViewerV1 {
             }
 
             if (resultIndex >= resultVaultsCount) {
-                skip = i + 1;
                 break;
             }
         }
 
         // It does not take into account that there may be disconnected volts
-        uint256 leftover = allVaultsCount - skip;
-        return (resultVaults, leftover);
+        uint256 leftover = allVaultsCount - i;
+        return (_filterNonZeroVaults(resultVaults, 0, resultIndex), leftover);
     }
 
     /// @dev common logic for vaultsByRole and vaultsByRoleBound

--- a/contracts/0.8.25/vaults/VaultHubViewerV1.sol
+++ b/contracts/0.8.25/vaults/VaultHubViewerV1.sol
@@ -160,6 +160,8 @@ contract VaultHubViewerV1 {
         uint256 resultVaultsCount = _to - _from;
         IVault[] memory resultVaults = new IVault[](resultVaultsCount);
         uint256 resultIndex = 0;
+        uint256 skip = 0;
+
 
         uint256 allVaultsCount = vaultHub.vaultsCount();
         for (uint256 i = 0; i < allVaultsCount; i++) {
@@ -171,13 +173,13 @@ contract VaultHubViewerV1 {
             }
 
             if (resultIndex >= resultVaultsCount) {
+                skip = i + 1;
                 break;
             }
         }
 
         // It does not take into account that there may be disconnected volts
-//        uint256 leftover = cycleIndex > _to ? cycleIndex - _to : 0;
-        uint256 leftover = 0;
+        uint256 leftover = allVaultsCount - skip;
         return (resultVaults, leftover);
     }
 

--- a/contracts/0.8.25/vaults/VaultHubViewerV1.sol
+++ b/contracts/0.8.25/vaults/VaultHubViewerV1.sol
@@ -134,9 +134,9 @@ contract VaultHubViewerV1 {
 
     /// @notice Returns connected vaults with limits
     /// @param _limit A limited number of vaults in the result
-    /// @param _offset Number shows how many vaults need to be passed
+    /// @param _offset A number how many vaults (connected and not connected) need to be skipped
     /// @return array of connected vaults
-    /// @return number of leftover connected vaults (it does not take into account that there may be disconnected volts)
+    /// @return number of leftover vaults (connected and not connected)
     function vaultsConnectedBound(
         uint256 _limit,
         uint256 _offset
@@ -183,6 +183,7 @@ contract VaultHubViewerV1 {
         }
 
         // It does not take into account that there may be disconnected volts
+        // Calc a leftover of ONLY connected vaults is expensive by gas
         uint256 leftover = i < allVaultsCount ? allVaultsCount - (i + 1) : 0;
         return (_filterNonZeroVaults(resultVaults, 0, resultIndex), leftover);
     }

--- a/contracts/0.8.25/vaults/VaultHubViewerV1.sol
+++ b/contracts/0.8.25/vaults/VaultHubViewerV1.sol
@@ -171,8 +171,8 @@ contract VaultHubViewerV1 {
 
         uint256 allVaultsCount = vaultHub.vaultsCount();
         uint256 i;
-        for (i = 0; i < allVaultsCount; i++) {
-            if (i >= _offset && !vaultHub.vaultSocket(i).isDisconnected) {
+        for (i = _offset; i < allVaultsCount; i++) {
+            if (!vaultHub.vaultSocket(i).isDisconnected) {
                 resultVaults[resultIndex] = IVault(vaultHub.vault(i));
                 resultIndex++;
             }

--- a/test/0.8.25/vaults/vault-hub-viewer/contracts/VaultHub__MockForHubViewer.sol
+++ b/test/0.8.25/vaults/vault-hub-viewer/contracts/VaultHub__MockForHubViewer.sol
@@ -61,6 +61,11 @@ contract VaultHub__MockForHubViewer {
     }
 
     function disconnectVault(address _vault) external {
+        // Just disconnectVault, without additional checks!!!
+        VaultHub.VaultHubStorage storage $ = _getVaultHubStorage();
+        uint256 index = $.vaultIndex[_vault];
+        $.sockets[index].isDisconnected = true;
+
         emit Mock__VaultDisconnected(_vault);
     }
 

--- a/test/0.8.25/vaults/vault-hub-viewer/contracts/VaultHub__MockForHubViewer.sol
+++ b/test/0.8.25/vaults/vault-hub-viewer/contracts/VaultHub__MockForHubViewer.sol
@@ -16,7 +16,7 @@ contract VaultHub__MockForHubViewer {
     uint256 internal constant BPS_BASE = 100_00;
     IStETH public immutable steth;
     // keccak256(abi.encode(uint256(keccak256("VaultHub")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant VAULT_HUB_STORAGE_LOCATION =
+    bytes32 private constant VAULT_HUB_STORAGE_SLOT =
         0xb158a1a9015c52036ff69e7937a7bb424e82a8c4cbec5c5309994af06d825300;
 
     constructor(IStETH _steth) {
@@ -104,7 +104,7 @@ contract VaultHub__MockForHubViewer {
 
     function _getVaultHubStorage() private pure returns (VaultHub.VaultHubStorage storage $) {
         assembly {
-            $.slot := VAULT_HUB_STORAGE_LOCATION
+            $.slot := VAULT_HUB_STORAGE_SLOT
         }
     }
 }

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -386,27 +386,28 @@ describe("VaultHubViewerV1", () => {
   context("vaultsConnectedBound", () => {
     beforeEach(async () => {
       await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
+
       await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
+      await hub.connect(hubSigner).disconnectVault(vaultDashboard.getAddress());
+
       await hub.connect(hubSigner).mock_connectVault(stakingVault.getAddress());
       await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
-
-      await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
     });
 
-    it("returns all connected vaults (the given range is greater than the number of vaults)", async () => {
-      const vaults = await vaultHubViewer.vaultsConnectedBound(0, 1_000);
+    it("returns connected vaults (the given limits are greater than the number of vaults)", async () => {
+      const vaults = await vaultHubViewer.vaultsConnectedBound(1_000, 0);
       // check a vaults length
       expect(vaults[0].length).to.equal(3);
       // check a leftover
       expect(vaults[1]).to.equal(0);
     });
 
-    it("returns all connected vaults in a given range", async () => {
-      const vaults = await vaultHubViewer.vaultsConnectedBound(1, 3);
+    it("returns connected vaults with limit and offset", async () => {
+      const vaults = await vaultHubViewer.vaultsConnectedBound(2, 1);
       // check a vaults length
       expect(vaults[0].length).to.equal(2);
       // check a leftover
-      expect(vaults[1]).to.equal(2);
+      expect(vaults[1]).to.equal(0);
     });
 
     it("returns all connected vaults (the given range does not include vaults)", async () => {
@@ -416,13 +417,13 @@ describe("VaultHubViewerV1", () => {
       // check a leftover
       expect(vaults[1]).to.equal(0);
     });
-
-    it("reverts if from is greater than to", async () => {
-      await expect(vaultHubViewer.vaultsConnectedBound(3, 1)).to.be.revertedWithCustomError(
-        vaultHubViewer,
-        "WrongPaginationRange",
-      );
-    });
+    //
+    // it("reverts if from is greater than to", async () => {
+    //   await expect(vaultHubViewer.vaultsConnectedBound(3, 1)).to.be.revertedWithCustomError(
+    //     vaultHubViewer,
+    //     "WrongPaginationRange",
+    //   );
+    // });
   });
 
   context("vaultsConnected 'highload'", () => {

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -235,33 +235,33 @@ describe("VaultHubViewerV1", () => {
     });
   });
 
-  context("vaultsConnected", () => {
-    beforeEach(async () => {
-      await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
-      await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
-      await hub.connect(hubSigner).mock_connectVault(stakingVault.getAddress());
-      await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
-    });
-
-    it("returns all connected vaults", async () => {
-      const vaults = await vaultHubViewer.vaultsConnected();
-      expect(vaults.length).to.equal(4);
-      expect(vaults[0]).to.equal(vaultDelegation);
-      expect(vaults[1]).to.equal(vaultDashboard);
-      expect(vaults[2]).to.equal(stakingVault);
-      expect(vaults[3]).to.equal(vaultCustom);
-    });
-
-    it("returns all connected vaults after disconnect the vaultCustom", async () => {
-      await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
-
-      const vaults = await vaultHubViewer.vaultsConnected();
-      expect(vaults.length).to.equal(3);
-      expect(vaults[0]).to.equal(vaultDelegation);
-      expect(vaults[1]).to.equal(vaultDashboard);
-      expect(vaults[2]).to.equal(stakingVault);
-    });
-  });
+  // context("vaultsConnected", () => {
+  //   beforeEach(async () => {
+  //     await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
+  //     await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
+  //     await hub.connect(hubSigner).mock_connectVault(stakingVault.getAddress());
+  //     await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
+  //   });
+  //
+  //   it("returns all connected vaults", async () => {
+  //     const vaults = await vaultHubViewer.vaultsConnected();
+  //     expect(vaults.length).to.equal(4);
+  //     expect(vaults[0]).to.equal(vaultDelegation);
+  //     expect(vaults[1]).to.equal(vaultDashboard);
+  //     expect(vaults[2]).to.equal(stakingVault);
+  //     expect(vaults[3]).to.equal(vaultCustom);
+  //   });
+  //
+  //   it("returns all connected vaults after disconnect the vaultCustom", async () => {
+  //     await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
+  //
+  //     const vaults = await vaultHubViewer.vaultsConnected();
+  //     expect(vaults.length).to.equal(3);
+  //     expect(vaults[0]).to.equal(vaultDelegation);
+  //     expect(vaults[1]).to.equal(vaultDashboard);
+  //     expect(vaults[2]).to.equal(stakingVault);
+  //   });
+  // });
 
   context("vaultsConnectedBound", () => {
     beforeEach(async () => {

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -495,7 +495,7 @@ describe("VaultHubViewerV1", () => {
     it(`checks gas estimation for vaultsConnected`, async () => {
       const gasEstimate = await ethers.provider.estimateGas({
         to: await vaultHubViewer.getAddress(),
-        data: vaultHubViewer.interface.encodeFunctionData("vaultsConnected", []),
+        data: vaultHubViewer.interface.encodeFunctionData("vaultsConnected"),
       });
       expect(gasEstimate).to.lte(50_000_000n);
     });

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -251,6 +251,16 @@ describe("VaultHubViewerV1", () => {
       expect(vaults[2]).to.equal(stakingVault);
       expect(vaults[3]).to.equal(vaultCustom);
     });
+
+    it("returns all connected vaults after disconnect the vaultCustom", async () => {
+      await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
+
+      const vaults = await vaultHubViewer.vaultsConnected();
+      expect(vaults.length).to.equal(3);
+      expect(vaults[0]).to.equal(vaultDelegation);
+      expect(vaults[1]).to.equal(vaultDashboard);
+      expect(vaults[2]).to.equal(stakingVault);
+    });
   });
 
   context("vaultsConnectedBound", () => {

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -393,7 +393,7 @@ describe("VaultHubViewerV1", () => {
       await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
     });
 
-    it("returns all connected vaults", async () => {
+    it("returns all connected vaults (the given range is greater than the number of vaults)", async () => {
       const vaults = await vaultHubViewer.vaultsConnectedBound(0, 1_000);
       // check a vaults length
       expect(vaults[0].length).to.equal(3);
@@ -407,6 +407,14 @@ describe("VaultHubViewerV1", () => {
       expect(vaults[0].length).to.equal(2);
       // check a leftover
       expect(vaults[1]).to.equal(2);
+    });
+
+    it("returns all connected vaults (the given range does not include vaults)", async () => {
+      const vaults = await vaultHubViewer.vaultsConnectedBound(1_000, 2_000);
+      // check a vaults length
+      expect(vaults[0].length).to.equal(0);
+      // check a leftover
+      expect(vaults[1]).to.equal(0);
     });
 
     it("reverts if from is greater than to", async () => {

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -166,6 +166,8 @@ describe("VaultHubViewerV1", () => {
   let hub: VaultHub__MockForHubViewer;
   let depositContract: DepositContract__MockForStakingVault;
   let stakingVault: StakingVault;
+  const stakingVaultArray: StakingVault[] = [];
+  const stakingVaultArrayCount = 100;
   let vaultDashboard: StakingVault;
   let vaultDelegation: StakingVault;
   let vaultCustom: StakingVault;
@@ -208,6 +210,12 @@ describe("VaultHubViewerV1", () => {
     // EOA controlled vault
     stakingVault = await deployStakingVault(vaultImpl, vaultOwner, operator);
 
+    // For "highload" testing
+    for (let i = 0; i <= stakingVaultArrayCount - 1; i++) {
+      const _stakingVault = await deployStakingVault(vaultImpl, vaultOwner, operator);
+      stakingVaultArray.push(_stakingVault);
+    }
+
     // Custom owner controlled vault
     const customdResult = await deployCustomOwner(vaultImpl, operator);
     vaultCustom = customdResult.stakingVault;
@@ -235,35 +243,7 @@ describe("VaultHubViewerV1", () => {
     });
   });
 
-  // context("vaultsConnected", () => {
-  //   beforeEach(async () => {
-  //     await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
-  //     await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
-  //     await hub.connect(hubSigner).mock_connectVault(stakingVault.getAddress());
-  //     await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
-  //   });
-  //
-  //   it("returns all connected vaults", async () => {
-  //     const vaults = await vaultHubViewer.vaultsConnected();
-  //     expect(vaults.length).to.equal(4);
-  //     expect(vaults[0]).to.equal(vaultDelegation);
-  //     expect(vaults[1]).to.equal(vaultDashboard);
-  //     expect(vaults[2]).to.equal(stakingVault);
-  //     expect(vaults[3]).to.equal(vaultCustom);
-  //   });
-  //
-  //   it("returns all connected vaults after disconnect the vaultCustom", async () => {
-  //     await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
-  //
-  //     const vaults = await vaultHubViewer.vaultsConnected();
-  //     expect(vaults.length).to.equal(3);
-  //     expect(vaults[0]).to.equal(vaultDelegation);
-  //     expect(vaults[1]).to.equal(vaultDashboard);
-  //     expect(vaults[2]).to.equal(stakingVault);
-  //   });
-  // });
-
-  context("vaultsConnectedBound", () => {
+  context("vaultsConnected", () => {
     beforeEach(async () => {
       await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
       await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
@@ -271,35 +251,23 @@ describe("VaultHubViewerV1", () => {
       await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
     });
 
-    it("checks gas estimation for vaultsConnectedBound(0, 4)", async () => {
-      const gasEstimate = await ethers.provider.estimateGas({
-        to: await vaultHubViewer.getAddress(),
-        data: vaultHubViewer.interface.encodeFunctionData("vaultsConnectedBound", [0, 4]),
-      });
-      expect(gasEstimate).to.lte(50_000_000n);
-    });
-
     it("returns all connected vaults", async () => {
-      const vaults = await vaultHubViewer.vaultsConnectedBound(0, 4);
-      // check a vaults length
-      expect(vaults[0].length).to.equal(4);
-      // check a leftover
-      expect(vaults[1]).to.equal(0);
+      const vaults = await vaultHubViewer.vaultsConnected();
+      expect(vaults.length).to.equal(4);
+      expect(vaults[0]).to.equal(vaultDelegation);
+      expect(vaults[1]).to.equal(vaultDashboard);
+      expect(vaults[2]).to.equal(stakingVault);
+      expect(vaults[3]).to.equal(vaultCustom);
     });
 
-    it("returns all connected vaults in a given range", async () => {
-      const vaults = await vaultHubViewer.vaultsConnectedBound(1, 3);
-      // check a vaults length
-      expect(vaults[0].length).to.equal(2);
-      // check a leftover (4 - 3 = 1)
-      expect(vaults[1]).to.equal(1);
-    });
+    it("returns all connected vaults after disconnect the vaultCustom", async () => {
+      await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
 
-    it("reverts if from is greater than to", async () => {
-      await expect(vaultHubViewer.vaultsConnectedBound(3, 1)).to.be.revertedWithCustomError(
-        vaultHubViewer,
-        "WrongPaginationRange",
-      );
+      const vaults = await vaultHubViewer.vaultsConnected();
+      expect(vaults.length).to.equal(3);
+      expect(vaults[0]).to.equal(vaultDelegation);
+      expect(vaults[1]).to.equal(vaultDashboard);
+      expect(vaults[2]).to.equal(stakingVault);
     });
   });
 
@@ -412,6 +380,54 @@ describe("VaultHubViewerV1", () => {
         4,
       );
       expect(vaults[0].length).to.equal(1);
+    });
+  });
+
+  context("vaultsConnectedBound", () => {
+    beforeEach(async () => {
+      await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
+      await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
+      await hub.connect(hubSigner).mock_connectVault(stakingVault.getAddress());
+      await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
+    });
+
+    it("returns all connected vaults", async () => {
+      const vaults = await vaultHubViewer.vaultsConnectedBound(0, 4);
+      // check a vaults length
+      expect(vaults[0].length).to.equal(4);
+      // check a leftover
+      expect(vaults[1]).to.equal(0);
+    });
+
+    it("returns all connected vaults in a given range", async () => {
+      const vaults = await vaultHubViewer.vaultsConnectedBound(1, 3);
+      // check a vaults length
+      expect(vaults[0].length).to.equal(2);
+      // check a leftover (4 - 3 = 1)
+      expect(vaults[1]).to.equal(1);
+    });
+
+    it("reverts if from is greater than to", async () => {
+      await expect(vaultHubViewer.vaultsConnectedBound(3, 1)).to.be.revertedWithCustomError(
+        vaultHubViewer,
+        "WrongPaginationRange",
+      );
+    });
+  });
+
+  context("vaultsConnected 'highload'", () => {
+    beforeEach(async () => {
+      stakingVaultArray.forEach(async (valult) => {
+        await hub.connect(hubSigner).mock_connectVault(valult.getAddress());
+      });
+    });
+
+    it(`checks gas estimation for vaultsConnectedBound(0, ${stakingVaultArrayCount - 1})`, async () => {
+      const gasEstimate = await ethers.provider.estimateGas({
+        to: await vaultHubViewer.getAddress(),
+        data: vaultHubViewer.interface.encodeFunctionData("vaultsConnectedBound", [0, stakingVaultArrayCount - 1]),
+      });
+      expect(gasEstimate).to.lte(50_000_000n);
     });
   });
 });

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -271,14 +271,28 @@ describe("VaultHubViewerV1", () => {
       await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
     });
 
+    it("checks gas estimation for vaultsConnectedBound(0, 4)", async () => {
+      const gasEstimate = await ethers.provider.estimateGas({
+        to: await vaultHubViewer.getAddress(),
+        data: vaultHubViewer.interface.encodeFunctionData("vaultsConnectedBound", [0, 4]),
+      });
+      expect(gasEstimate).to.lte(50_000_000n);
+    });
+
     it("returns all connected vaults", async () => {
       const vaults = await vaultHubViewer.vaultsConnectedBound(0, 4);
+      // check a vaults length
       expect(vaults[0].length).to.equal(4);
+      // check a leftover
+      expect(vaults[1]).to.equal(0);
     });
 
     it("returns all connected vaults in a given range", async () => {
       const vaults = await vaultHubViewer.vaultsConnectedBound(1, 3);
+      // check a vaults length
       expect(vaults[0].length).to.equal(2);
+      // check a leftover (4 - 3 = 1)
+      expect(vaults[1]).to.equal(1);
     });
 
     it("reverts if from is greater than to", async () => {

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -167,7 +167,7 @@ describe("VaultHubViewerV1", () => {
   let depositContract: DepositContract__MockForStakingVault;
   let stakingVault: StakingVault;
   const stakingVaultArray: StakingVault[] = [];
-  const stakingVaultArrayCount = 100;
+  const stakingVaultArrayCount = 20;
   let vaultDashboard: StakingVault;
   let vaultDelegation: StakingVault;
   let vaultCustom: StakingVault;
@@ -240,34 +240,6 @@ describe("VaultHubViewerV1", () => {
       await expect(ethers.deployContract("VaultHubViewerV1", [ethers.ZeroAddress]))
         .to.be.revertedWithCustomError(vaultHubViewer, "ZeroArgument")
         .withArgs("_vaultHubAddress");
-    });
-  });
-
-  context("vaultsConnected", () => {
-    beforeEach(async () => {
-      await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
-      await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
-      await hub.connect(hubSigner).mock_connectVault(stakingVault.getAddress());
-      await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
-    });
-
-    it("returns all connected vaults", async () => {
-      const vaults = await vaultHubViewer.vaultsConnected();
-      expect(vaults.length).to.equal(4);
-      expect(vaults[0]).to.equal(vaultDelegation);
-      expect(vaults[1]).to.equal(vaultDashboard);
-      expect(vaults[2]).to.equal(stakingVault);
-      expect(vaults[3]).to.equal(vaultCustom);
-    });
-
-    it("returns all connected vaults after disconnect the vaultCustom", async () => {
-      await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
-
-      const vaults = await vaultHubViewer.vaultsConnected();
-      expect(vaults.length).to.equal(3);
-      expect(vaults[0]).to.equal(vaultDelegation);
-      expect(vaults[1]).to.equal(vaultDashboard);
-      expect(vaults[2]).to.equal(stakingVault);
     });
   });
 
@@ -383,7 +355,7 @@ describe("VaultHubViewerV1", () => {
     });
   });
 
-  context("vaultsConnectedBound", () => {
+  context("vaultsConnected", () => {
     beforeEach(async () => {
       await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
       await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
@@ -392,9 +364,39 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns all connected vaults", async () => {
-      const vaults = await vaultHubViewer.vaultsConnectedBound(0, 4);
+      const vaults = await vaultHubViewer.vaultsConnected();
+      expect(vaults.length).to.equal(4);
+      expect(vaults[0]).to.equal(vaultDelegation);
+      expect(vaults[1]).to.equal(vaultDashboard);
+      expect(vaults[2]).to.equal(stakingVault);
+      expect(vaults[3]).to.equal(vaultCustom);
+    });
+
+    it("returns all connected vaults after disconnect the vaultCustom", async () => {
+      await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
+
+      const vaults = await vaultHubViewer.vaultsConnected();
+      expect(vaults.length).to.equal(3);
+      expect(vaults[0]).to.equal(vaultDelegation);
+      expect(vaults[1]).to.equal(vaultDashboard);
+      expect(vaults[2]).to.equal(stakingVault);
+    });
+  });
+
+  context("vaultsConnectedBound", () => {
+    beforeEach(async () => {
+      await hub.connect(hubSigner).mock_connectVault(vaultDelegation.getAddress());
+      await hub.connect(hubSigner).mock_connectVault(vaultDashboard.getAddress());
+      await hub.connect(hubSigner).mock_connectVault(stakingVault.getAddress());
+      await hub.connect(hubSigner).mock_connectVault(vaultCustom.getAddress());
+
+      await hub.connect(hubSigner).disconnectVault(vaultCustom.getAddress());
+    });
+
+    it("returns all connected vaults", async () => {
+      const vaults = await vaultHubViewer.vaultsConnectedBound(0, 1_000);
       // check a vaults length
-      expect(vaults[0].length).to.equal(4);
+      expect(vaults[0].length).to.equal(3);
       // check a leftover
       expect(vaults[1]).to.equal(0);
     });
@@ -403,8 +405,8 @@ describe("VaultHubViewerV1", () => {
       const vaults = await vaultHubViewer.vaultsConnectedBound(1, 3);
       // check a vaults length
       expect(vaults[0].length).to.equal(2);
-      // check a leftover (4 - 3 = 1)
-      expect(vaults[1]).to.equal(1);
+      // check a leftover
+      expect(vaults[1]).to.equal(2);
     });
 
     it("reverts if from is greater than to", async () => {

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -441,7 +441,7 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns connected vaults (the given limits are greater than the number of vaults)", async () => {
-      // Add a 2 second delay to remove side effects
+      // Add a 2 seconds delay to remove side effects
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       const vaults = await vaultHubViewer.vaultsConnectedBound(1_000, 0);
@@ -452,7 +452,7 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns all connected vaults (the given limits does not include vaults)", async () => {
-      // Add a 2 second delay to remove side effects
+      // Add a 2 seconds delay to remove side effects
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       const vaults = await vaultHubViewer.vaultsConnectedBound(1_000, 1_000);
@@ -463,7 +463,7 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns connected vaults with limit=2 and offset=2", async () => {
-      // Add a 2 second delay to remove side effects
+      // Add a 2 seconds delay to remove side effects
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       const vaults = await vaultHubViewer.vaultsConnectedBound(2, 2);
@@ -474,7 +474,7 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns connected vaults with limit=2 and offset=10", async () => {
-      // Add a 2 second delay to remove side effects
+      // Add a 2 seconds delay to remove side effects
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       const vaults = await vaultHubViewer.vaultsConnectedBound(2, 10);

--- a/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
+++ b/test/0.8.25/vaults/vault-hub-viewer/vault-hub-viewer.ts
@@ -441,8 +441,8 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns connected vaults (the given limits are greater than the number of vaults)", async () => {
-      // Add a 2 seconds delay to remove side effects
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      // Add a 4 seconds delay to remove side effects
+      await new Promise((resolve) => setTimeout(resolve, 4000));
 
       const vaults = await vaultHubViewer.vaultsConnectedBound(1_000, 0);
       // check a vaults length
@@ -452,8 +452,8 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns all connected vaults (the given limits does not include vaults)", async () => {
-      // Add a 2 seconds delay to remove side effects
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      // Add a 4 seconds delay to remove side effects
+      await new Promise((resolve) => setTimeout(resolve, 4000));
 
       const vaults = await vaultHubViewer.vaultsConnectedBound(1_000, 1_000);
       // check a vaults length
@@ -463,8 +463,8 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns connected vaults with limit=2 and offset=2", async () => {
-      // Add a 2 seconds delay to remove side effects
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      // Add a 4 seconds delay to remove side effects
+      await new Promise((resolve) => setTimeout(resolve, 4000));
 
       const vaults = await vaultHubViewer.vaultsConnectedBound(2, 2);
       // check a vaults length
@@ -474,8 +474,8 @@ describe("VaultHubViewerV1", () => {
     });
 
     it("returns connected vaults with limit=2 and offset=10", async () => {
-      // Add a 2 seconds delay to remove side effects
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      // Add a 4 seconds delay to remove side effects
+      await new Promise((resolve) => setTimeout(resolve, 4000));
 
       const vaults = await vaultHubViewer.vaultsConnectedBound(2, 10);
       // check a vaults length


### PR DESCRIPTION
The `vaultsConnectedBound` was optimized (speed and gas).
Also added tests for any amount of vaults.

## Context

noop

## Problem

Current pagination in the `vaultsConnectedBound` is expensive (like the `vaultsConnected`) by gas.
This PR decreases a gas.
Comparison:

```
Vaults amount is 300

// old implementations
vaultsConnectedBound(0, 10) - gasEstimate: 2_305_540n

// new implementations
vaultsConnectedBound(10, 0) - gasEstimate: 180_870n
```

## Solution

Change the internal logic in the `_vaultsConnectedBound` without going through all the vaults.
