### PR TITLE
Fix parameter naming inconsistency in OracleDaemonConfig error

### DIFF
--- a/contracts/0.8.9/OracleDaemonConfig.sol
+++ b/contracts/0.8.9/OracleDaemonConfig.sol
@@ -77,7 +77,7 @@ contract OracleDaemonConfig is AccessControlEnumerable {
     error EmptyValue(string key);
     error ValueDoesntExist(string key);
     error ZeroAddress();
-    error ValueIsSame(string key, bytes value);
+    error ValueIsSame(string key, bytes _value);
 
     event ConfigValueSet(string key, bytes value);
     event ConfigValueUpdated(string key, bytes value);


### PR DESCRIPTION
Standardizes parameter naming in error declarations by adding underscore prefix to parameter names in ValueExists, EmptyValue, and ValueDoesntExist errors to match the style used in ValueIsSame error.