### PR TITLE
feat: ssz porting from csm

### DIFF
--- a/contracts/0.8.25/lib/BeaconTypes.sol
+++ b/contracts/0.8.25/lib/BeaconTypes.sol
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.25;
+
+struct Validator {
+    bytes pubkey;
+    bytes32 withdrawalCredentials;
+    uint64 effectiveBalance;
+    bool slashed;
+    uint64 activationEligibilityEpoch;
+    uint64 activationEpoch;
+    uint64 exitEpoch;
+    uint64 withdrawableEpoch;
+}
+struct BeaconBlockHeader {
+    uint64 slot;
+    uint64 proposerIndex;
+    bytes32 parentRoot;
+    bytes32 stateRoot;
+    bytes32 bodyRoot;
+}

--- a/contracts/0.8.25/lib/GIndex.sol
+++ b/contracts/0.8.25/lib/GIndex.sol
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+/*
+ GIndex library from CSM
+ original: https://github.com/lidofinance/community-staking-module/blob/7071c2096983a7780a5f147963aaa5405c0badb1/src/lib/GIndex.sol
+*/
+
+pragma solidity 0.8.25;
+
+type GIndex is bytes32;
+
+using {isRoot, isParentOf, index, width, shr, shl, concat, unwrap, pow} for GIndex global;
+
+error IndexOutOfRange();
+
+/// @param gI Is a generalized index of a node in a tree.
+/// @param p Is a power of a tree level the node belongs to.
+/// @return GIndex
+function pack(uint256 gI, uint8 p) pure returns (GIndex) {
+    if (gI > type(uint248).max) {
+        revert IndexOutOfRange();
+    }
+
+    // NOTE: We can consider adding additional metadata like a fork version.
+    return GIndex.wrap(bytes32((gI << 8) | p));
+}
+
+function unwrap(GIndex self) pure returns (bytes32) {
+    return GIndex.unwrap(self);
+}
+
+function isRoot(GIndex self) pure returns (bool) {
+    return index(self) == 1;
+}
+
+function index(GIndex self) pure returns (uint256) {
+    return uint256(unwrap(self)) >> 8;
+}
+
+function width(GIndex self) pure returns (uint256) {
+    return 1 << pow(self);
+}
+
+function pow(GIndex self) pure returns (uint8) {
+    return uint8(uint256(unwrap(self)));
+}
+
+/// @return Generalized index of the nth neighbor of the node to the right.
+function shr(GIndex self, uint256 n) pure returns (GIndex) {
+    uint256 i = index(self);
+    uint256 w = width(self);
+
+    if ((i % w) + n >= w) {
+        revert IndexOutOfRange();
+    }
+
+    return pack(i + n, pow(self));
+}
+
+/// @return Generalized index of the nth neighbor of the node to the left.
+function shl(GIndex self, uint256 n) pure returns (GIndex) {
+    uint256 i = index(self);
+    uint256 w = width(self);
+
+    if (i % w < n) {
+        revert IndexOutOfRange();
+    }
+
+    return pack(i - n, pow(self));
+}
+
+// See https://github.com/protolambda/remerkleable/blob/91ed092d08ef0ba5ab076f0a34b0b371623db728/remerkleable/tree.py#L46
+function concat(GIndex lhs, GIndex rhs) pure returns (GIndex) {
+    uint256 lhsMSbIndex = fls(index(lhs));
+    uint256 rhsMSbIndex = fls(index(rhs));
+
+    if (lhsMSbIndex + 1 + rhsMSbIndex > 248) {
+        revert IndexOutOfRange();
+    }
+
+    return pack((index(lhs) << rhsMSbIndex) | (index(rhs) ^ (1 << rhsMSbIndex)), pow(rhs));
+}
+
+function isParentOf(GIndex self, GIndex child) pure returns (bool) {
+    uint256 parentIndex = index(self);
+    uint256 childIndex = index(child);
+
+    if (parentIndex >= childIndex) {
+        return false;
+    }
+
+    while (childIndex > 0) {
+        if (childIndex == parentIndex) {
+            return true;
+        }
+
+        childIndex = childIndex >> 1;
+    }
+
+    return false;
+}
+
+/// @dev From Solady LibBit, see https://github.com/Vectorized/solady/blob/main/src/utils/LibBit.sol.
+/// @dev Find last set.
+/// Returns the index of the most significant bit of `x`,
+/// counting from the least significant bit position.
+/// If `x` is zero, returns 256.
+function fls(uint256 x) pure returns (uint256 r) {
+    /// @solidity memory-safe-assembly
+    assembly {
+        // prettier-ignore
+        r := or(shl(8, iszero(x)), shl(7, lt(0xffffffffffffffffffffffffffffffff, x)))
+        r := or(r, shl(6, lt(0xffffffffffffffff, shr(r, x))))
+        r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+        r := or(r, shl(4, lt(0xffff, shr(r, x))))
+        r := or(r, shl(3, lt(0xff, shr(r, x))))
+        // prettier-ignore
+        r := or(r, byte(and(0x1f, shr(shr(r, x), 0x8421084210842108cc6318c6db6d54be)),
+                0x0706060506020504060203020504030106050205030304010505030400000000))
+    }
+}

--- a/contracts/0.8.25/lib/SSZ.sol
+++ b/contracts/0.8.25/lib/SSZ.sol
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+
+/*
+ SSZ library from CSM
+ original: https://github.com/lidofinance/community-staking-module/blob/7071c2096983a7780a5f147963aaa5405c0badb1/src/lib/SSZ.sol
+*/
+
+pragma solidity 0.8.25;
+
+import {BeaconBlockHeader, Validator} from "./BeaconTypes.sol";
+import {GIndex} from "./GIndex.sol";
+
+library SSZ {
+    error BranchHasMissingItem();
+    error BranchHasExtraItem();
+    error InvalidProof();
+
+    function hashTreeRoot(BeaconBlockHeader memory header) internal view returns (bytes32 root) {
+        bytes32[8] memory nodes = [
+            toLittleEndian(header.slot),
+            toLittleEndian(header.proposerIndex),
+            header.parentRoot,
+            header.stateRoot,
+            header.bodyRoot,
+            bytes32(0),
+            bytes32(0),
+            bytes32(0)
+        ];
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Count of nodes to hash
+            let count := 8
+
+            // Loop over levels
+            // prettier-ignore
+            for { } 1 { } {
+                // Loop over nodes at the given depth
+
+                // Initialize `offset` to the offset of `proof` elements in memory.
+                let target := nodes
+                let source := nodes
+                let end := add(source, shl(5, count))
+
+                // prettier-ignore
+                for { } 1 { } {
+                    // Read next two hashes to hash
+                    mcopy(0x00, source, 0x40)
+
+                    // Call sha256 precompile
+                    let result := staticcall(
+                        gas(),
+                        0x02,
+                        0x00,
+                        0x40,
+                        0x00,
+                        0x20
+                    )
+
+                    if iszero(result) {
+                        // Precompiles returns no data on OutOfGas error.
+                        revert(0, 0)
+                    }
+
+                    // Store the resulting hash at the target location
+                    mstore(target, mload(0x00))
+
+                    // Advance the pointers
+                    target := add(target, 0x20)
+                    source := add(source, 0x40)
+
+                    if iszero(lt(source, end)) {
+                        break
+                    }
+                }
+
+                count := shr(1, count)
+                if eq(count, 1) {
+                    root := mload(0x00)
+                    break
+                }
+            }
+        }
+    }
+
+    function hashTreeRoot(Validator memory validator) internal view returns (bytes32 root) {
+        bytes32 pubkeyRoot;
+
+        assembly {
+            // Dynamic data types such as bytes are stored at the specified offset.
+            let offset := mload(validator)
+            // Copy the pubkey to the scratch space.
+            mcopy(0x00, add(offset, 32), 48)
+            // Clear the last 16 bytes.
+            mcopy(48, 0x60, 16)
+            // Call sha256 precompile.
+            let result := staticcall(gas(), 0x02, 0x00, 0x40, 0x00, 0x20)
+
+            if iszero(result) {
+                // Precompiles returns no data on OutOfGas error.
+                revert(0, 0)
+            }
+
+            pubkeyRoot := mload(0x00)
+        }
+
+        bytes32[8] memory nodes = [
+            pubkeyRoot,
+            validator.withdrawalCredentials,
+            toLittleEndian(validator.effectiveBalance),
+            toLittleEndian(validator.slashed),
+            toLittleEndian(validator.activationEligibilityEpoch),
+            toLittleEndian(validator.activationEpoch),
+            toLittleEndian(validator.exitEpoch),
+            toLittleEndian(validator.withdrawableEpoch)
+        ];
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Count of nodes to hash
+            let count := 8
+
+            // Loop over levels
+            // prettier-ignore
+            for { } 1 { } {
+                // Loop over nodes at the given depth
+
+                // Initialize `offset` to the offset of `proof` elements in memory.
+                let target := nodes
+                let source := nodes
+                let end := add(source, shl(5, count))
+
+                // prettier-ignore
+                for { } 1 { } {
+                    // Read next two hashes to hash
+                    mcopy(0x00, source, 0x40)
+
+                    // Call sha256 precompile
+                    let result := staticcall(
+                        gas(),
+                        0x02,
+                        0x00,
+                        0x40,
+                        0x00,
+                        0x20
+                    )
+
+                    if iszero(result) {
+                        // Precompiles returns no data on OutOfGas error.
+                        revert(0, 0)
+                    }
+
+                    // Store the resulting hash at the target location
+                    mstore(target, mload(0x00))
+
+                    // Advance the pointers
+                    target := add(target, 0x20)
+                    source := add(source, 0x40)
+
+                    if iszero(lt(source, end)) {
+                        break
+                    }
+                }
+
+                count := shr(1, count)
+                if eq(count, 1) {
+                    root := mload(0x00)
+                    break
+                }
+            }
+        }
+    }
+
+    /// @notice Modified version of `verify` from Solady `MerkleProofLib` to support generalized indices and sha256 precompile.
+    /// @dev Reverts if `leaf` doesn't exist in the Merkle tree with `root`, given `proof`.
+    function verifyProof(bytes32[] calldata proof, bytes32 root, bytes32 leaf, GIndex gI) internal view {
+        uint256 index = gI.index();
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Check if `proof` is empty.
+            if iszero(proof.length) {
+                // revert InvalidProof()
+                mstore(0x00, 0x09bde339)
+                revert(0x1c, 0x04)
+            }
+            // Left shift by 5 is equivalent to multiplying by 0x20.
+            let end := add(proof.offset, shl(5, proof.length))
+            // Initialize `offset` to the offset of `proof` in the calldata.
+            let offset := proof.offset
+            // Iterate over proof elements to compute root hash.
+            // prettier-ignore
+            for { } 1 { } {
+                // Slot of `leaf` in scratch space.
+                // If the condition is true: 0x20, otherwise: 0x00.
+                let scratch := shl(5, and(index, 1))
+                index := shr(1, index)
+                if iszero(index) {
+                    // revert BranchHasExtraItem()
+                    mstore(0x00, 0x5849603f)
+                    // 0x1c = 28 => offset in 32-byte word of a slot 0x00
+                    revert(0x1c, 0x04)
+                }
+                // Store elements to hash contiguously in scratch space.
+                // Scratch space is 64 bytes (0x00 - 0x3f) and both elements are 32 bytes.
+                mstore(scratch, leaf)
+                mstore(xor(scratch, 0x20), calldataload(offset))
+                // Call sha256 precompile.
+                let result := staticcall(
+                    gas(),
+                    0x02,
+                    0x00,
+                    0x40,
+                    0x00,
+                    0x20
+                )
+
+                if iszero(result) {
+                    // Precompile returns no data on OutOfGas error.
+                    revert(0, 0)
+                }
+
+                // Reuse `leaf` to store the hash to reduce stack operations.
+                leaf := mload(0x00)
+                offset := add(offset, 0x20)
+                if iszero(lt(offset, end)) {
+                    break
+                }
+            }
+
+            if iszero(eq(index, 1)) {
+                // revert BranchHasMissingItem()
+                mstore(0x00, 0x1b6661c3)
+                revert(0x1c, 0x04)
+            }
+
+            if iszero(eq(leaf, root)) {
+                // revert InvalidProof()
+                mstore(0x00, 0x09bde339)
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+
+    // See https://github.com/succinctlabs/telepathy-contracts/blob/5aa4bb7/src/libraries/SimpleSerialize.sol#L17-L28
+    function toLittleEndian(uint256 v) internal pure returns (bytes32) {
+        v =
+            ((v & 0xFF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00) >> 8) |
+            ((v & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+        v =
+            ((v & 0xFFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000) >> 16) |
+            ((v & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) << 16);
+        v =
+            ((v & 0xFFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000) >> 32) |
+            ((v & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) << 32);
+        v =
+            ((v & 0xFFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF0000000000000000) >> 64) |
+            ((v & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) << 64);
+        v = (v >> 128) | (v << 128);
+        return bytes32(v);
+    }
+
+    function toLittleEndian(bool v) internal pure returns (bytes32) {
+        return bytes32(v ? 1 << 248 : 0);
+    }
+}

--- a/test/0.8.25/contracts/Utilities.sol
+++ b/test/0.8.25/contracts/Utilities.sol
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2025 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.25;
+
+contract Utilities {
+    error FreeMemoryPointerOverflowed();
+    error ZeroSlotIsNotZero();
+
+    /// See https://github.com/Vectorized/solady - MIT licensed.
+    /// @dev Fills the memory with junk, for more robust testing of inline assembly
+    /// which reads/write to the memory.
+    function _brutalizeMemory() private view {
+        // To prevent a solidity 0.8.13 bug.
+        // See: https://blog.soliditylang.org/2022/06/15/inline-assembly-memory-side-effects-bug
+        // Basically, we need to access a solidity variable from the assembly to
+        // tell the compiler that this assembly block is not in isolation.
+        uint256 zero;
+        /// @solidity memory-safe-assembly
+        assembly {
+            let offset := mload(0x40) // Start the offset at the free memory pointer.
+            calldatacopy(offset, zero, calldatasize())
+
+            // Fill the 64 bytes of scratch space with garbage.
+            mstore(zero, add(caller(), gas()))
+            mstore(0x20, keccak256(offset, calldatasize()))
+            mstore(zero, keccak256(zero, 0x40))
+
+            let r0 := mload(zero)
+            let r1 := mload(0x20)
+
+            let cSize := add(codesize(), iszero(codesize()))
+            if iszero(lt(cSize, 32)) {
+                cSize := sub(cSize, and(mload(0x02), 0x1f))
+            }
+            let start := mod(mload(0x10), cSize)
+            let size := mul(sub(cSize, start), gt(cSize, start))
+            let times := div(0x7ffff, cSize)
+            if iszero(lt(times, 128)) {
+                times := 128
+            }
+
+            // Occasionally offset the offset by a pseudorandom large amount.
+            // Can't be too large, or we will easily get out-of-gas errors.
+            offset := add(offset, mul(iszero(and(r1, 0xf)), and(r0, 0xfffff)))
+
+            // Fill the free memory with garbage.
+            // prettier-ignore
+            for { let w := not(0) } 1 {} {
+                mstore(offset, r0)
+                mstore(add(offset, 0x20), r1)
+                offset := add(offset, 0x40)
+                // We use codecopy instead of the identity precompile
+                // to avoid polluting the `forge test -vvvv` output with tons of junk.
+                codecopy(offset, start, size)
+                codecopy(add(offset, size), 0, start)
+                offset := add(offset, cSize)
+                times := add(times, w) // `sub(times, 1)`.
+                if iszero(times) { break }
+            }
+        }
+    }
+
+    /// See https://github.com/Vectorized/solady - MIT licensed.
+    /// @dev Check if the free memory pointer and the zero slot are not contaminated.
+    /// Useful for cases where these slots are used for temporary storage.
+    function _checkMemory() internal pure {
+        bool zeroSlotIsNotZero;
+        bool freeMemoryPointerOverflowed;
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Write ones to the free memory, to make subsequent checks fail if
+            // insufficient memory is allocated.
+            mstore(mload(0x40), not(0))
+            // Test at a lower, but reasonable limit for more safety room.
+            if gt(mload(0x40), 0xffffffff) {
+                freeMemoryPointerOverflowed := 1
+            }
+            // Check the value of the zero slot.
+            zeroSlotIsNotZero := mload(0x60)
+        }
+        if (freeMemoryPointerOverflowed) revert FreeMemoryPointerOverflowed();
+        if (zeroSlotIsNotZero) revert ZeroSlotIsNotZero();
+    }
+
+    /// See https://github.com/Vectorized/solady - MIT licensed.
+    /// @dev Fills the memory with junk, for more robust testing of inline assembly
+    /// which reads/write to the memory.
+    modifier brutalizeMemory() {
+        _brutalizeMemory();
+        _;
+        _checkMemory();
+    }
+}

--- a/test/0.8.25/lib/GIndex.t.sol
+++ b/test/0.8.25/lib/GIndex.t.sol
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2024 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+import {GIndex, pack, IndexOutOfRange, fls} from "../../../contracts/0.8.25/lib/GIndex.sol";
+import {SSZ} from "../../../contracts/0.8.25/lib/SSZ.sol";
+
+// Wrap the library internal methods to make an actual call to them.
+// Supposed to be used with `expectRevert` cheatcode.
+contract Library {
+    function concat(GIndex lhs, GIndex rhs) public pure returns (GIndex) {
+        return lhs.concat(rhs);
+    }
+
+    function shr(GIndex self, uint256 n) public pure returns (GIndex) {
+        return self.shr(n);
+    }
+
+    function shl(GIndex self, uint256 n) public pure returns (GIndex) {
+        return self.shl(n);
+    }
+}
+
+contract GIndexTest is Test {
+    GIndex internal ZERO = GIndex.wrap(bytes32(0));
+    GIndex internal ROOT = GIndex.wrap(0x0000000000000000000000000000000000000000000000000000000000000100);
+    GIndex internal MAX = GIndex.wrap(bytes32(type(uint256).max));
+
+    Library internal lib;
+
+    error Log2Undefined();
+
+    function setUp() public {
+        lib = new Library();
+    }
+
+    function test_pack() public {
+        GIndex gI;
+
+        gI = pack(0x7b426f79504c6a8e9d31415b722f696e705c8a3d9f41, 42);
+        assertEq(
+            gI.unwrap(),
+            0x0000000000000000007b426f79504c6a8e9d31415b722f696e705c8a3d9f412a,
+            "Invalid gindex encoded"
+        );
+
+        assertEq(MAX.unwrap(), bytes32(type(uint256).max), "Invalid gindex encoded");
+    }
+
+    function test_isRootTrue() public {
+        assertTrue(ROOT.isRoot(), "ROOT is not root gindex");
+    }
+
+    function test_isRootFalse() public {
+        GIndex gI;
+
+        gI = pack(0, 0);
+        assertFalse(gI.isRoot(), "Expected [0,0].isRoot() to be false");
+
+        gI = pack(42, 0);
+        assertFalse(gI.isRoot(), "Expected [42,0].isRoot() to be false");
+
+        gI = pack(42, 4);
+        assertFalse(gI.isRoot(), "Expected [42,4].isRoot() to be false");
+
+        gI = pack(2048, 4);
+        assertFalse(gI.isRoot(), "Expected [2048,4].isRoot() to be false");
+
+        gI = pack(type(uint248).max, type(uint8).max);
+        assertFalse(gI.isRoot(), "Expected [uint248.max,uint8.max].isRoot() to be false");
+    }
+
+    function test_isParentOf_Truthy() public {
+        assertTrue(pack(1024, 0).isParentOf(pack(2048, 0)));
+        assertTrue(pack(1024, 0).isParentOf(pack(2049, 0)));
+        assertTrue(pack(1024, 9).isParentOf(pack(2048, 0)));
+        assertTrue(pack(1024, 9).isParentOf(pack(2049, 0)));
+        assertTrue(pack(1024, 0).isParentOf(pack(2048, 9)));
+        assertTrue(pack(1024, 0).isParentOf(pack(2049, 9)));
+        assertTrue(pack(1023, 0).isParentOf(pack(4094, 0)));
+        assertTrue(pack(1024, 0).isParentOf(pack(4098, 0)));
+    }
+
+    function testFuzz_ROOT_isParentOfAnyChild(GIndex rhs) public {
+        vm.assume(rhs.index() > 1);
+        assertTrue(ROOT.isParentOf(rhs));
+    }
+
+    function testFuzz_isParentOf_LessThanAnchor(GIndex lhs, GIndex rhs) public {
+        vm.assume(rhs.index() < lhs.index());
+        assertFalse(lhs.isParentOf(rhs));
+    }
+
+    function test_isParentOf_OffTheBranch() public {
+        assertFalse(pack(1024, 0).isParentOf(pack(2050, 0)));
+        assertFalse(pack(1024, 0).isParentOf(pack(2051, 0)));
+        assertFalse(pack(1024, 0).isParentOf(pack(2047, 0)));
+        assertFalse(pack(1024, 0).isParentOf(pack(2046, 0)));
+        assertFalse(pack(1024, 9).isParentOf(pack(2050, 0)));
+        assertFalse(pack(1024, 9).isParentOf(pack(2051, 0)));
+        assertFalse(pack(1024, 9).isParentOf(pack(2047, 0)));
+        assertFalse(pack(1024, 9).isParentOf(pack(2046, 0)));
+        assertFalse(pack(1024, 0).isParentOf(pack(2050, 9)));
+        assertFalse(pack(1024, 0).isParentOf(pack(2051, 9)));
+        assertFalse(pack(1024, 0).isParentOf(pack(2047, 9)));
+        assertFalse(pack(1024, 0).isParentOf(pack(2046, 9)));
+        assertFalse(pack(1023, 0).isParentOf(pack(2048, 0)));
+        assertFalse(pack(1023, 0).isParentOf(pack(2049, 0)));
+        assertFalse(pack(1023, 9).isParentOf(pack(2048, 0)));
+        assertFalse(pack(1023, 9).isParentOf(pack(2049, 0)));
+        assertFalse(pack(1023, 0).isParentOf(pack(4098, 0)));
+        assertFalse(pack(1024, 0).isParentOf(pack(4094, 0)));
+    }
+
+    function test_concat() public {
+        assertEq(pack(2, 99).concat(pack(3, 99)).unwrap(), pack(5, 99).unwrap());
+        assertEq(pack(31, 99).concat(pack(3, 99)).unwrap(), pack(63, 99).unwrap());
+        assertEq(pack(31, 99).concat(pack(6, 99)).unwrap(), pack(126, 99).unwrap());
+        assertEq(ROOT.concat(pack(2, 1)).concat(pack(5, 1)).concat(pack(9, 1)).unwrap(), pack(73, 1).unwrap());
+        assertEq(ROOT.concat(pack(2, 9)).concat(pack(5, 1)).concat(pack(9, 4)).unwrap(), pack(73, 4).unwrap());
+
+        assertEq(ROOT.concat(MAX).unwrap(), MAX.unwrap());
+    }
+
+    function test_concat_RevertsIfZeroGIndex() public {
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.concat(ZERO, pack(1024, 1));
+
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.concat(pack(1024, 1), ZERO);
+    }
+
+    function test_concat_BigIndicesBorderCases() public view {
+        lib.concat(pack(2 ** 9, 0), pack(2 ** 238, 0));
+        lib.concat(pack(2 ** 47, 0), pack(2 ** 200, 0));
+        lib.concat(pack(2 ** 199, 0), pack(2 ** 48, 0));
+    }
+
+    function test_concat_RevertsIfTooBigIndices() public {
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.concat(MAX, MAX);
+
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.concat(pack(2 ** 48, 0), pack(2 ** 200, 0));
+
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.concat(pack(2 ** 200, 0), pack(2 ** 48, 0));
+    }
+
+    function testFuzz_concat_WithRoot(GIndex rhs) public {
+        vm.assume(rhs.index() > 0);
+        assertEq(ROOT.concat(rhs).unwrap(), rhs.unwrap(), "`concat` with a root should return right-hand side value");
+    }
+
+    function testFuzz_concat_isParentOf(GIndex lhs, GIndex rhs) public {
+        // Left-hand side value can be a root.
+        vm.assume(lhs.index() > 0);
+        // But root.concat(root) will result in a root value again, and root is not a parent for itself.
+        vm.assume(rhs.index() > 1);
+        // Overflow check.
+        vm.assume(fls(lhs.index()) + 1 + fls(rhs.index()) < 248);
+
+        assertTrue(lhs.isParentOf(lhs.concat(rhs)), "Left-hand side value should be a parent of `concat` result");
+        assertFalse(lhs.concat(rhs).isParentOf(lhs), "`concat` result can't be a parent for the left-hand side value");
+        assertFalse(lhs.concat(rhs).isParentOf(rhs), "`concat` result can't be a parent for the right-hand side value");
+    }
+
+    function testFuzz_unpack(uint248 index, uint8 pow) public {
+        GIndex gI = pack(index, pow);
+        assertEq(gI.index(), index);
+        assertEq(gI.width(), 2 ** pow);
+    }
+
+    function test_shr() public {
+        GIndex gI;
+
+        gI = pack(1024, 4);
+        assertEq(gI.shr(0).unwrap(), pack(1024, 4).unwrap());
+        assertEq(gI.shr(1).unwrap(), pack(1025, 4).unwrap());
+        assertEq(gI.shr(15).unwrap(), pack(1039, 4).unwrap());
+
+        gI = pack(1031, 4);
+        assertEq(gI.shr(0).unwrap(), pack(1031, 4).unwrap());
+        assertEq(gI.shr(1).unwrap(), pack(1032, 4).unwrap());
+        assertEq(gI.shr(8).unwrap(), pack(1039, 4).unwrap());
+
+        gI = pack(2049, 4);
+        assertEq(gI.shr(0).unwrap(), pack(2049, 4).unwrap());
+        assertEq(gI.shr(1).unwrap(), pack(2050, 4).unwrap());
+        assertEq(gI.shr(14).unwrap(), pack(2063, 4).unwrap());
+    }
+
+    function test_shr_AfterConcat() public {
+        GIndex gI;
+        GIndex gIParent = pack(5, 4);
+
+        gI = pack(1024, 4);
+        assertEq(gIParent.concat(gI).shr(0).unwrap(), pack(5120, 4).unwrap());
+        assertEq(gIParent.concat(gI).shr(1).unwrap(), pack(5121, 4).unwrap());
+        assertEq(gIParent.concat(gI).shr(15).unwrap(), pack(5135, 4).unwrap());
+
+        gI = pack(1031, 4);
+        assertEq(gIParent.concat(gI).shr(0).unwrap(), pack(5127, 4).unwrap());
+        assertEq(gIParent.concat(gI).shr(1).unwrap(), pack(5128, 4).unwrap());
+        assertEq(gIParent.concat(gI).shr(8).unwrap(), pack(5135, 4).unwrap());
+
+        gI = pack(2049, 4);
+        assertEq(gIParent.concat(gI).shr(0).unwrap(), pack(10241, 4).unwrap());
+        assertEq(gIParent.concat(gI).shr(1).unwrap(), pack(10242, 4).unwrap());
+        assertEq(gIParent.concat(gI).shr(14).unwrap(), pack(10255, 4).unwrap());
+    }
+
+    function test_shr_OffTheWidth() public {
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(ROOT, 1);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(pack(1024, 4), 16);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(pack(1031, 4), 9);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(pack(1023, 4), 1);
+    }
+
+    function test_shr_OffTheWidth_AfterConcat() public {
+        GIndex gIParent = pack(154, 4);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(gIParent.concat(ROOT), 1);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(gIParent.concat(pack(1024, 4)), 16);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(gIParent.concat(pack(1031, 4)), 9);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(gIParent.concat(pack(1023, 4)), 1);
+    }
+
+    function testFuzz_shr_OffTheWidth_AfterConcat(GIndex lhs, GIndex rhs, uint256 shift) public {
+        // Indices concatenation overflow protection.
+        vm.assume(fls(lhs.index()) + 1 + fls(rhs.index()) < 248);
+        vm.assume(rhs.index() >= rhs.width());
+        unchecked {
+            vm.assume(rhs.width() + shift > rhs.width());
+            vm.assume(lhs.concat(rhs).index() + shift > lhs.concat(rhs).index());
+        }
+
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shr(lhs.concat(rhs), rhs.width() + shift);
+    }
+
+    function test_shl() public {
+        GIndex gI;
+
+        gI = pack(1023, 4);
+        assertEq(gI.shl(0).unwrap(), pack(1023, 4).unwrap());
+        assertEq(gI.shl(1).unwrap(), pack(1022, 4).unwrap());
+        assertEq(gI.shl(15).unwrap(), pack(1008, 4).unwrap());
+
+        gI = pack(1031, 4);
+        assertEq(gI.shl(0).unwrap(), pack(1031, 4).unwrap());
+        assertEq(gI.shl(1).unwrap(), pack(1030, 4).unwrap());
+        assertEq(gI.shl(7).unwrap(), pack(1024, 4).unwrap());
+
+        gI = pack(2063, 4);
+        assertEq(gI.shl(0).unwrap(), pack(2063, 4).unwrap());
+        assertEq(gI.shl(1).unwrap(), pack(2062, 4).unwrap());
+        assertEq(gI.shl(15).unwrap(), pack(2048, 4).unwrap());
+    }
+
+    function test_shl_AfterConcat() public {
+        GIndex gI;
+        GIndex gIParent = pack(5, 4);
+
+        gI = pack(1023, 4);
+        assertEq(gIParent.concat(gI).shl(0).unwrap(), pack(3071, 4).unwrap());
+        assertEq(gIParent.concat(gI).shl(1).unwrap(), pack(3070, 4).unwrap());
+        assertEq(gIParent.concat(gI).shl(15).unwrap(), pack(3056, 4).unwrap());
+
+        gI = pack(1031, 4);
+        assertEq(gIParent.concat(gI).shl(0).unwrap(), pack(5127, 4).unwrap());
+        assertEq(gIParent.concat(gI).shl(1).unwrap(), pack(5126, 4).unwrap());
+        assertEq(gIParent.concat(gI).shl(7).unwrap(), pack(5120, 4).unwrap());
+
+        gI = pack(2063, 4);
+        assertEq(gIParent.concat(gI).shl(0).unwrap(), pack(10255, 4).unwrap());
+        assertEq(gIParent.concat(gI).shl(1).unwrap(), pack(10254, 4).unwrap());
+        assertEq(gIParent.concat(gI).shl(15).unwrap(), pack(10240, 4).unwrap());
+    }
+
+    function test_shl_OffTheWidth() public {
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(ROOT, 1);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(pack(1024, 4), 1);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(pack(1031, 4), 9);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(pack(1023, 4), 16);
+    }
+
+    function test_shl_OffTheWidth_AfterConcat() public {
+        GIndex gIParent = pack(154, 4);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(gIParent.concat(ROOT), 1);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(gIParent.concat(pack(1024, 4)), 1);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(gIParent.concat(pack(1031, 4)), 9);
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(gIParent.concat(pack(1023, 4)), 16);
+    }
+
+    function testFuzz_shl_OffTheWidth_AfterConcat(GIndex lhs, GIndex rhs, uint256 shift) public {
+        // Indices concatenation overflow protection.
+        vm.assume(fls(lhs.index()) + 1 + fls(rhs.index()) < 248);
+        vm.assume(rhs.index() >= rhs.width());
+        vm.assume(shift > rhs.index() % rhs.width());
+
+        vm.expectRevert(IndexOutOfRange.selector);
+        lib.shl(lhs.concat(rhs), shift);
+    }
+
+    function testFuzz_shl_shr_Idempotent(GIndex gI, uint256 shift) public {
+        vm.assume(gI.index() > 0);
+        vm.assume(gI.index() >= gI.width());
+        vm.assume(shift < gI.index() % gI.width());
+
+        assertEq(lib.shr(lib.shl(gI, shift), shift).unwrap(), gI.unwrap());
+    }
+
+    function testFuzz_shr_shl_Idempotent(GIndex gI, uint256 shift) public {
+        vm.assume(gI.index() > 0);
+        vm.assume(gI.index() >= gI.width());
+        vm.assume(shift < gI.width() - (gI.index() % gI.width()));
+
+        assertEq(lib.shl(lib.shr(gI, shift), shift).unwrap(), gI.unwrap());
+    }
+
+    function test_fls() public {
+        for (uint256 i = 1; i < 255; i++) {
+            assertEq(fls((1 << i) - 1), i - 1);
+            assertEq(fls((1 << i)), i);
+            assertEq(fls((1 << i) + 1), i);
+        }
+
+        assertEq(fls(3), 1); // 0011
+        assertEq(fls(7), 2); // 0101
+        assertEq(fls(10), 3); // 1010
+        assertEq(fls(300), 8); // 0001 0010 1100
+        assertEq(fls(0), 256);
+    }
+}

--- a/test/0.8.25/lib/SSZ.t.sol
+++ b/test/0.8.25/lib/SSZ.t.sol
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: 2024 Lido <info@lido.fi>
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+import {BeaconBlockHeader, Validator} from "../../../contracts/0.8.25/lib/BeaconTypes.sol";
+import {GIndex, pack} from "../../../contracts/0.8.25/lib/GIndex.sol";
+import {Utilities} from "../contracts/Utilities.sol";
+import {SSZ} from "../../../contracts/0.8.25/lib/SSZ.sol";
+
+// Wrap the library internal methods to make an actual call to them.
+// Supposed to be used with `expectRevert` cheatcode and to pass
+// calldata arguments.
+contract Library {
+    function verifyProof(bytes32[] calldata proof, bytes32 root, bytes32 leaf, GIndex gI) external view {
+        SSZ.verifyProof(proof, root, leaf, gI);
+    }
+}
+
+contract SSZTest is Utilities, Test {
+    Library internal lib;
+
+    function setUp() public {
+        lib = new Library();
+    }
+
+    function test_toLittleEndianUint() public pure {
+        uint256 v = 0x1234567890ABCDEF;
+        bytes32 expected = bytes32(bytes.concat(hex"EFCDAB9078563412", bytes24(0)));
+        bytes32 actual = SSZ.toLittleEndian(v);
+        assertEq(actual, expected);
+    }
+
+    function test_toLittleEndianUintZero() public pure {
+        bytes32 actual = SSZ.toLittleEndian(0);
+        assertEq(actual, bytes32(0));
+    }
+
+    function test_toLittleEndianFalse() public pure {
+        bool v = false;
+        bytes32 expected = 0x0000000000000000000000000000000000000000000000000000000000000000;
+        bytes32 actual = SSZ.toLittleEndian(v);
+        assertEq(actual, expected);
+    }
+
+    function test_toLittleEndianTrue() public pure {
+        bool v = true;
+        bytes32 expected = 0x0100000000000000000000000000000000000000000000000000000000000000;
+        bytes32 actual = SSZ.toLittleEndian(v);
+        assertEq(actual, expected);
+    }
+
+    function testFuzz_toLittleEndian_Idempotent(uint256 v) public pure {
+        uint256 n = v;
+        n = uint256(SSZ.toLittleEndian(n));
+        n = uint256(SSZ.toLittleEndian(n));
+        assertEq(n, v);
+    }
+
+    function test_ValidatorRootExitedSlashed() public view {
+        Validator memory v = Validator({
+            pubkey: hex"91760f8a17729cfcb68bfc621438e5d9dfa831cd648e7b2b7d33540a7cbfda1257e4405e67cd8d3260351ab3ff71b213",
+            withdrawalCredentials: 0x01000000000000000000000006676e8584342cc8b6052cfdf381c3a281f00ac8,
+            effectiveBalance: 30000000000,
+            slashed: true,
+            activationEligibilityEpoch: 242529,
+            activationEpoch: 242551,
+            exitEpoch: 242556,
+            withdrawableEpoch: 250743
+        });
+
+        bytes32 expected = 0xe4674dc5c27e7d3049fcd298745c00d3e314f03d33c877f64bf071d3b77eb942;
+        bytes32 actual = SSZ.hashTreeRoot(v);
+        assertEq(actual, expected);
+    }
+
+    function test_ValidatorRootActive() public view {
+        Validator memory v = Validator({
+            pubkey: hex"8fb78536e82bcec34e98fff85c907f0a8e6f4b1ccdbf1e8ace26b59eb5a06d16f34e50837f6c490e2ad6a255db8d543b",
+            withdrawalCredentials: 0x0023b9d00bf66e7f8071208a85afde59b3148dea046ee3db5d79244880734881,
+            effectiveBalance: 32000000000,
+            slashed: false,
+            activationEligibilityEpoch: 2593,
+            activationEpoch: 5890,
+            exitEpoch: type(uint64).max,
+            withdrawableEpoch: type(uint64).max
+        });
+
+        bytes32 expected = 0x60fb91184416404ddfc62bef6df9e9a52c910751daddd47ea426aabaf19dfa09;
+        bytes32 actual = SSZ.hashTreeRoot(v);
+        assertEq(actual, expected);
+    }
+
+    function test_ValidatorRootExtraBytesInPubkey() public view {
+        Validator memory v = Validator({
+            pubkey: hex"8fb78536e82bcec34e98fff85c907f0a8e6f4b1ccdbf1e8ace26b59eb5a06d16f34e50837f6c490e2ad6a255db8d543bDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+            withdrawalCredentials: 0x0023b9d00bf66e7f8071208a85afde59b3148dea046ee3db5d79244880734881,
+            effectiveBalance: 32000000000,
+            slashed: false,
+            activationEligibilityEpoch: 2593,
+            activationEpoch: 5890,
+            exitEpoch: type(uint64).max,
+            withdrawableEpoch: type(uint64).max
+        });
+
+        bytes32 expected = 0x60fb91184416404ddfc62bef6df9e9a52c910751daddd47ea426aabaf19dfa09;
+        bytes32 actual = SSZ.hashTreeRoot(v);
+        assertEq(actual, expected);
+    }
+
+    function test_ValidatorRoot_AllZeroes() public view {
+        Validator memory v = Validator({
+            pubkey: hex"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            withdrawalCredentials: 0x0000000000000000000000000000000000000000000000000000000000000000,
+            effectiveBalance: 0,
+            slashed: false,
+            activationEligibilityEpoch: 0,
+            activationEpoch: 0,
+            exitEpoch: 0,
+            withdrawableEpoch: 0
+        });
+
+        bytes32 expected = 0xfa324a462bcb0f10c24c9e17c326a4e0ebad204feced523eccaf346c686f06ee;
+        bytes32 actual = SSZ.hashTreeRoot(v);
+        assertEq(actual, expected);
+    }
+
+    function test_ValidatorRoot_AllOnes() public view {
+        Validator memory v = Validator({
+            pubkey: hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            withdrawalCredentials: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+            effectiveBalance: type(uint64).max,
+            slashed: true,
+            activationEligibilityEpoch: type(uint64).max,
+            activationEpoch: type(uint64).max,
+            exitEpoch: type(uint64).max,
+            withdrawableEpoch: type(uint64).max
+        });
+
+        bytes32 expected = 0x29c03a7cc9a8047ff05619a04bb6e60440a791e6ac3fe7d72e6fe9037dd3696f;
+        bytes32 actual = SSZ.hashTreeRoot(v);
+        assertEq(actual, expected);
+    }
+
+    function testFuzz_validatorRoot_memory(Validator memory v) public view brutalizeMemory {
+        SSZ.hashTreeRoot(v);
+    }
+
+    function test_BeaconBlockHeaderRoot() public view {
+        // Can be obtained via /eth/v1/beacon/headers/{block_id}.
+        BeaconBlockHeader memory h = BeaconBlockHeader({
+            slot: 7472518,
+            proposerIndex: 152834,
+            parentRoot: 0x4916af1ff31b06f1b27125d2d20cd26e123c425a4b34ebd414e5f0120537e78d,
+            stateRoot: 0x76ca64f3732754bc02c7966271fb6356a9464fe5fce85be8e7abc403c8c7b56b,
+            bodyRoot: 0x6d858c959f1c95f411dba526c4ae9ab8b2690f8b1e59ed1b79ad963ab798b01a
+        });
+
+        bytes32 expected = 0x26631ee28ab4dd44a39c3756e03714d6a35a256560de5e2885caef9c3efd5516;
+        bytes32 actual = SSZ.hashTreeRoot(h);
+        assertEq(actual, expected);
+    }
+
+    function test_BeaconBlockHeaderRoot_AllZeroes() public view {
+        BeaconBlockHeader memory h = BeaconBlockHeader({
+            slot: 0,
+            proposerIndex: 0,
+            parentRoot: 0x0000000000000000000000000000000000000000000000000000000000000000,
+            stateRoot: 0x0000000000000000000000000000000000000000000000000000000000000000,
+            bodyRoot: 0x0000000000000000000000000000000000000000000000000000000000000000
+        });
+
+        bytes32 expected = 0xc78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c;
+        bytes32 actual = SSZ.hashTreeRoot(h);
+        assertEq(actual, expected);
+    }
+
+    function test_BeaconBlockHeaderRoot_AllOnes() public view {
+        BeaconBlockHeader memory h = BeaconBlockHeader({
+            slot: type(uint64).max,
+            proposerIndex: type(uint64).max,
+            parentRoot: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+            stateRoot: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff,
+            bodyRoot: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+        });
+
+        bytes32 expected = 0x5ebe9f2b0267944bd80dd5cde20317a91d07225ff12e9cd5ba1e834c05cc2b05;
+        bytes32 actual = SSZ.hashTreeRoot(h);
+        assertEq(actual, expected);
+    }
+
+    function testFuzz_BeaconBlockHeaderRoot_memory(BeaconBlockHeader memory h) public view brutalizeMemory {
+        SSZ.hashTreeRoot(h);
+    }
+
+    // For the tests below, assume there's the following tree from the bottom up:
+    // --
+    // 0x0000000000000000000000000000000000000000000000000000000000000000
+    // 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5
+    // 0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30
+    // 0x21ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba85
+    // --
+    // 0x0a4b105f69a6f41c3b3efc9bb5ac525b5b557a524039a13c657a916d8eb04451
+    // 0xf4551dd23f47858f0e66957db62a0bced8cfd5e9cbd63f2fd73672ed0db7c124
+    // --
+    // 0xda1c902c54a4386439ce622d7e527dc11decace28ebb902379cba91c4a116b1c
+
+    function test_verifyProof_HappyPath() public view {
+        bytes32[] memory proof = new bytes32[](2);
+
+        // prettier-ignore
+        {
+            proof[0] = 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5;
+            proof[1] = 0xf4551dd23f47858f0e66957db62a0bced8cfd5e9cbd63f2fd73672ed0db7c124;
+        }
+
+        lib.verifyProof(
+            proof,
+            0xda1c902c54a4386439ce622d7e527dc11decace28ebb902379cba91c4a116b1c,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            pack(4, 0)
+        );
+
+        // prettier-ignore
+        {
+            proof[0] = 0x0000000000000000000000000000000000000000000000000000000000000000;
+            proof[1] = 0xf4551dd23f47858f0e66957db62a0bced8cfd5e9cbd63f2fd73672ed0db7c124;
+        }
+
+        lib.verifyProof(
+            proof,
+            0xda1c902c54a4386439ce622d7e527dc11decace28ebb902379cba91c4a116b1c,
+            0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5,
+            pack(5, 0)
+        );
+    }
+
+    function test_verifyProof_OneItem() public view brutalizeMemory {
+        bytes32[] memory proof = new bytes32[](1);
+
+        // prettier-ignore
+        proof[0] = 0xf4551dd23f47858f0e66957db62a0bced8cfd5e9cbd63f2fd73672ed0db7c124;
+
+        lib.verifyProof(
+            proof,
+            0xda1c902c54a4386439ce622d7e527dc11decace28ebb902379cba91c4a116b1c,
+            0x0a4b105f69a6f41c3b3efc9bb5ac525b5b557a524039a13c657a916d8eb04451,
+            pack(2, 0)
+        );
+    }
+
+    function test_verifyProof_RevertWhen_NoProof() public brutalizeMemory {
+        vm.expectRevert(SSZ.InvalidProof.selector);
+
+        // bytes32(0) is a valid proof for the inputs.
+        lib.verifyProof(
+            new bytes32[](0),
+            0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            pack(2, 0)
+        );
+    }
+
+    function test_verifyProof_RevertWhen_ProvingRoot() public brutalizeMemory {
+        vm.expectRevert(SSZ.InvalidProof.selector);
+
+        lib.verifyProof(
+            new bytes32[](0),
+            0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b,
+            0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b,
+            pack(1, 0)
+        );
+    }
+
+    function test_verifyProof_RevertWhen_InvalidProof() public brutalizeMemory {
+        bytes32[] memory proof = new bytes32[](2);
+
+        // prettier-ignore
+        {
+            proof[0] = 0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30;
+            proof[1] = 0xf4551dd23f47858f0e66957db62a0bced8cfd5e9cbd63f2fd73672ed0db7c124;
+        }
+
+        vm.expectRevert(SSZ.InvalidProof.selector);
+
+        lib.verifyProof(
+            proof,
+            0xda1c902c54a4386439ce622d7e527dc11decace28ebb902379cba91c4a116b1c,
+            0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5,
+            pack(4, 0)
+        );
+    }
+
+    function test_verifyProof_RevertWhen_WrongGIndex() public brutalizeMemory {
+        bytes32[] memory proof = new bytes32[](2);
+
+        // prettier-ignore
+        {
+            proof[0] = 0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5;
+            proof[1] = 0xf4551dd23f47858f0e66957db62a0bced8cfd5e9cbd63f2fd73672ed0db7c124;
+        }
+
+        vm.expectRevert(SSZ.InvalidProof.selector);
+
+        lib.verifyProof(
+            proof,
+            0xda1c902c54a4386439ce622d7e527dc11decace28ebb902379cba91c4a116b1c,
+            0x0000000000000000000000000000000000000000000000000000000000000000,
+            pack(5, 0)
+        );
+    }
+
+    function test_verifyProof_RevertWhen_BranchHasExtraItem() public brutalizeMemory {
+        bytes32[] memory proof = new bytes32[](2);
+
+        // prettier-ignore
+        {
+            proof[0] = 0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30;
+            proof[1] = 0xf4551dd23f47858f0e66957db62a0bced8cfd5e9cbd63f2fd73672ed0db7c124;
+        }
+
+        vm.expectRevert(SSZ.BranchHasExtraItem.selector);
+
+        lib.verifyProof(
+            proof,
+            0xda1c902c54a4386439ce622d7e527dc11decace28ebb902379cba91c4a116b1c,
+            0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5,
+            pack(2, 0)
+        );
+    }
+
+    function test_verifyProof_RevertWhen_BranchHasMissingItem() public brutalizeMemory {
+        bytes32[] memory proof = new bytes32[](2);
+
+        // prettier-ignore
+        {
+            proof[0] = 0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30;
+            proof[1] = 0xf4551dd23f47858f0e66957db62a0bced8cfd5e9cbd63f2fd73672ed0db7c124;
+        }
+
+        vm.expectRevert(SSZ.BranchHasMissingItem.selector);
+
+        lib.verifyProof(
+            proof,
+            0xda1c902c54a4386439ce622d7e527dc11decace28ebb902379cba91c4a116b1c,
+            0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5,
+            pack(8, 0)
+        );
+    }
+
+    function testFuzz_verifyProof_MemorySafe(
+        bytes32[] calldata proof,
+        bytes32 root,
+        bytes32 leaf,
+        GIndex gI
+    ) public view {
+        try this.verifyProofCallJunkMemory(proof, root, leaf, gI) {} catch {}
+    }
+
+    function verifyProofCallJunkMemory(
+        bytes32[] calldata proof,
+        bytes32 root,
+        bytes32 leaf,
+        GIndex gI
+    ) external view brutalizeMemory {
+        SSZ.verifyProof(proof, root, leaf, gI);
+    }
+}


### PR DESCRIPTION
Porting SSZ Library from CSM to Core Repository

Both `Triggerable Withdrawals` and `Vaults` require SSZ for Merkle proof verification.
This merge request aims to streamline development efforts by extracting and centralizing the shared SSZ-related code, which was originally ported from CSM.