### PR TITLE
chore: fix incorrect constant for zero address in ethers.js

### DIFF
--- a/scripts/scratch/steps/0070-deploy-dao.ts
+++ b/scripts/scratch/steps/0070-deploy-dao.ts
@@ -86,7 +86,7 @@ async function saveStateFromNewDAOTx(newDAOReceipt: ContractTransactionReceipt) 
     constructorArgs: [
       // see LidoTemplate._createToken
       state[Sk.miniMeTokenFactory].address,
-      ethers.ZeroAddress,
+      ethers.constants.AddressZero,
       0,
       state[Sk.daoInitialSettings].token.name,
       18, // see LidoTemplate.TOKEN_DECIMALS


### PR DESCRIPTION
## Context  
In ethers.js, the correct constant for the zero address is `ethers.constants.AddressZero`.  

## Problem  
The code was incorrectly using `ethers.ZeroAddress`, which does not exist in ethers.js.  

## Solution  
I replaced `ethers.ZeroAddress` with `ethers.constants.AddressZero` to ensure the correct usage of the zero address constant in the code.