### PR TITLE
Move part of the regression integration tests from scripts repo

### DIFF
--- a/lib/event.ts
+++ b/lib/event.ts
@@ -38,11 +38,32 @@ export function findEventsWithInterfaces(
   receipt: ContractTransactionReceipt,
   eventName: string,
   interfaces: Interface[],
+  numberOfIndexedParams?: number,
 ): LogDescription[] {
   const events: LogDescription[] = [];
   const notParsedLogs: Log[] = [];
 
+  const topics0OfInterest = interfaces.map((iface) => {
+    return iface.getEvent(eventName)?.topicHash;
+  });
+
   receipt.logs.forEach((entry) => {
+    if (
+      !topics0OfInterest.includes(entry.topics[0]) ||
+      (numberOfIndexedParams !== undefined && entry.topics.length !== numberOfIndexedParams + 1)
+    ) {
+      // We do preliminary filtering here to avoid unnecessary parsing
+      // and possible 'Error parsing log with interface "data out-of-bounds"'
+      // errors in iface.parseLog used inside of parseLogEntry if parseLog
+      // called upon log not matching the interface
+      // We also filter out logs with different number of indexed params
+      // to distinguish cases like Transfer of ERC20 and NFT which have
+      // the same signature but different number of indexed params:
+      //   event Transfer(address indexed from, address indexed to, uint256 value);
+      //   event Transfer(address indexed from, address indexed to, uint256 indexed requestId);
+      return;
+    }
+
     const logDescription = parseLogEntry(entry, interfaces);
     if (logDescription) {
       events.push(logDescription);
@@ -58,6 +79,8 @@ export function findEventsWithInterfaces(
   return events.filter((e) => e.name === eventName);
 }
 
+// NB: This function might mislead because receipt.logs might be Log[]
+//     instead of EventLog[] and no event would be found
 export function findEvents(receipt: ContractTransactionReceipt, eventName: string) {
   const events = [];
 

--- a/lib/oracle.ts
+++ b/lib/oracle.ts
@@ -33,7 +33,7 @@ export const EXTRA_DATA_FORMAT_LIST = 1n;
 export const EXTRA_DATA_TYPE_STUCK_VALIDATORS = 1n;
 export const EXTRA_DATA_TYPE_EXITED_VALIDATORS = 2n;
 
-const DEFAULT_REPORT_FIELDS: OracleReport = {
+export const DEFAULT_REPORT_FIELDS: OracleReport = {
   consensusVersion: 1n,
   refSlot: 0n,
   numValidators: 0n,

--- a/lib/protocol/context.ts
+++ b/lib/protocol/context.ts
@@ -39,6 +39,7 @@ export const getProtocolContext = async (): Promise<ProtocolContext> => {
     signers,
     interfaces,
     flags,
+    isScratch: true, // NB: gonna be updated upon merge of upgrade PR
     getSigner: async (signer: Signer, balance?: bigint) => getSigner(signer, balance, signers),
     getEvents: (receipt: ContractTransactionReceipt, eventName: string, extraInterfaces: Interface[] = []) =>
       findEventsWithInterfaces(receipt, eventName, [...interfaces, ...extraInterfaces]),

--- a/lib/protocol/helpers/accounting.ts
+++ b/lib/protocol/helpers/accounting.ts
@@ -24,7 +24,6 @@ import { ProtocolContext } from "../types";
 const ZERO_HASH = new Uint8Array(32).fill(0);
 const ZERO_BYTES32 = "0x" + Buffer.from(ZERO_HASH).toString("hex");
 const SHARE_RATE_PRECISION = 10n ** 27n;
-const MIN_MEMBERS_COUNT = 3n;
 
 export type OracleReportParams = {
   clDiff?: bigint;
@@ -686,7 +685,7 @@ const reachConsensus = async (
 /**
  * Helper function to get report data items in the required order.
  */
-const getReportDataItems = (data: AccountingOracle.ReportDataStruct) => [
+export const getReportDataItems = (data: AccountingOracle.ReportDataStruct) => [
   data.consensusVersion,
   data.refSlot,
   data.numValidators,
@@ -708,7 +707,7 @@ const getReportDataItems = (data: AccountingOracle.ReportDataStruct) => [
 /**
  * Helper function to calculate hash of the report data.
  */
-const calcReportDataHash = (items: ReturnType<typeof getReportDataItems>) => {
+export const calcReportDataHash = (items: ReturnType<typeof getReportDataItems>) => {
   const types = [
     "uint256", // consensusVersion
     "uint256", // refSlot
@@ -740,7 +739,7 @@ const getOracleCommitteeMemberAddress = (id: number) => certainAddress(`AO:HC:OC
 /**
  * Ensure that the oracle committee has the required number of members.
  */
-export const ensureOracleCommitteeMembers = async (ctx: ProtocolContext, minMembersCount = MIN_MEMBERS_COUNT) => {
+export const ensureOracleCommitteeMembers = async (ctx: ProtocolContext, minMembersCount: bigint, quorum: bigint) => {
   const { hashConsensus } = ctx.contracts;
 
   const members = await hashConsensus.getFastLaneMembers();
@@ -766,7 +765,7 @@ export const ensureOracleCommitteeMembers = async (ctx: ProtocolContext, minMemb
     log.warning(`Adding oracle committee member ${count}`);
 
     const address = getOracleCommitteeMemberAddress(count);
-    await hashConsensus.connect(agentSigner).addMember(address, minMembersCount);
+    await hashConsensus.connect(agentSigner).addMember(address, quorum);
 
     addresses.push(address);
 

--- a/lib/protocol/helpers/dsm.ts
+++ b/lib/protocol/helpers/dsm.ts
@@ -1,0 +1,73 @@
+import { expect } from "chai";
+
+import { certainAddress, impersonate, log } from "lib";
+
+import { ProtocolContext } from "../types";
+
+/**
+ * Ensures that the DSM has the required number of guardians and quorum.
+ */
+export const ensureDsmGuardians = async (ctx: ProtocolContext, minGuardiansCount: bigint, quorum: bigint) => {
+  const { depositSecurityModule: dsm } = ctx.contracts;
+
+  const guardians = await dsm.getGuardians();
+  const addresses = guardians.map((address) => address.toLowerCase());
+
+  if (addresses.length >= minGuardiansCount) {
+    log.debug("DSM guardians count is sufficient", {
+      "Min guardians count": minGuardiansCount,
+      "Guardians count": addresses.length,
+      "Guardians": addresses.join(", "),
+    });
+    return;
+  }
+
+  const ownerSigner = await impersonate(await dsm.getOwner());
+
+  let count = addresses.length;
+  const newGuardians: string[] = [];
+  while (count < minGuardiansCount) {
+    log.warning(`Adding DSM guardian ${count}`);
+
+    const address = certainAddress(`dsm_guardian_${count}`);
+    newGuardians.push(address);
+
+    count++;
+  }
+
+  await dsm.connect(ownerSigner).addGuardians(newGuardians, quorum);
+
+  log.debug("Checked DSM guardians count", {
+    "Min guardians count": minGuardiansCount,
+    "Guardians count": count,
+    "Added guardians": newGuardians.join(", "),
+  });
+
+  const guardiansAfter = await dsm.getGuardians();
+  expect(guardiansAfter.length).to.be.gte(minGuardiansCount);
+};
+
+/**
+ * Removes all existing guardians and sets a single guardian with quorum of 1
+ */
+export const setSingleGuardian = async (ctx: ProtocolContext, guardian: string) => {
+  const { depositSecurityModule: dsm } = ctx.contracts;
+  const ownerSigner = await impersonate(await dsm.getOwner());
+
+  // Remove all existing guardians
+  const guardians = await dsm.getGuardians();
+  for (const existingGuardian of guardians) {
+    await dsm.connect(ownerSigner).removeGuardian(existingGuardian, 1);
+  }
+
+  // Add single guardian with quorum 1
+  await dsm.connect(ownerSigner).addGuardians([guardian], 1);
+
+  log.debug("Set single DSM guardian", {
+    Guardian: guardian,
+  });
+
+  const guardiansAfter = await dsm.getGuardians();
+  expect(guardiansAfter.length).to.equal(1);
+  expect(guardiansAfter[0]).to.equal(guardian);
+};

--- a/lib/protocol/helpers/index.ts
+++ b/lib/protocol/helpers/index.ts
@@ -11,7 +11,10 @@ export {
   waitNextAvailableReportTime,
   handleOracleReport,
   report,
+  getReportDataItems,
+  calcReportDataHash,
 } from "./accounting";
 
 export { sdvtEnsureOperators } from "./sdvt";
 export { norEnsureOperators } from "./nor";
+export { ensureDsmGuardians } from "./dsm";

--- a/lib/protocol/helpers/sdvt.ts
+++ b/lib/protocol/helpers/sdvt.ts
@@ -8,7 +8,7 @@ import { ProtocolContext } from "../types";
 import { getOperatorManagerAddress, getOperatorName, getOperatorRewardAddress } from "./nor";
 import { depositAndReportValidators } from "./staking";
 
-const SDVT_MODULE_ID = 2n;
+export const SDVT_MODULE_ID = 2n;
 const MIN_OPS_COUNT = 3n;
 const MIN_OP_KEYS_COUNT = 10n;
 

--- a/lib/protocol/provision.ts
+++ b/lib/protocol/provision.ts
@@ -1,6 +1,7 @@
 import { log } from "lib";
 
 import {
+  ensureDsmGuardians,
   ensureHashConsensusInitialEpoch,
   ensureOracleCommitteeMembers,
   ensureStakeLimit,
@@ -25,7 +26,7 @@ export const provision = async (ctx: ProtocolContext) => {
 
   await ensureHashConsensusInitialEpoch(ctx);
 
-  await ensureOracleCommitteeMembers(ctx, 5n);
+  await ensureOracleCommitteeMembers(ctx, 5n, 4n);
 
   await unpauseStaking(ctx);
   await unpauseWithdrawalQueue(ctx);
@@ -36,6 +37,8 @@ export const provision = async (ctx: ProtocolContext) => {
   await finalizeWithdrawalQueue(ctx);
 
   await ensureStakeLimit(ctx);
+
+  await ensureDsmGuardians(ctx, 3n, 2n);
 
   alreadyProvisioned = true;
 

--- a/lib/protocol/types.ts
+++ b/lib/protocol/types.ts
@@ -167,6 +167,7 @@ export type ProtocolContext = {
   signers: ProtocolSigners;
   interfaces: Array<BaseContract["interface"]>;
   flags: ProtocolContextFlags;
+  isScratch: boolean;
   getSigner: (signer: Signer, balance?: bigint) => Promise<HardhatEthersSigner>;
   getEvents: (
     receipt: ContractTransactionReceipt,

--- a/test/integration/core/dsm-keys-unvetting.integration.ts
+++ b/test/integration/core/dsm-keys-unvetting.integration.ts
@@ -7,13 +7,14 @@ import { time } from "@nomicfoundation/hardhat-network-helpers";
 
 import { DepositSecurityModule } from "typechain-types";
 
-import { certainAddress, DSMUnvetMessage, ether, impersonate } from "lib";
+import { certainAddress, DSMUnvetMessage, ether, findEventsWithInterfaces, impersonate } from "lib";
 import { getProtocolContext, ProtocolContext } from "lib/protocol";
 import { setSingleGuardian } from "lib/protocol/helpers/dsm";
 import { norAddNodeOperator, norAddOperatorKeys, norSetOperatorStakingLimit } from "lib/protocol/helpers/nor";
 
 import { Snapshot } from "test/suite";
 
+// Just an arbitrary account for using in tests
 const GUARDIAN_PRIVATE_KEY = "0x516b8a7d9290502f5661da81f0cf43893e3d19cb9aea3c426cfb36e8186e9c09";
 
 describe("Integration: DSM keys unvetting", () => {
@@ -43,7 +44,7 @@ describe("Integration: DSM keys unvetting", () => {
 
   it("Should allow owner to set max operators per unvetting", async () => {
     const owner = await dsm.getOwner();
-    const ownerSigner = await impersonate(owner);
+    const ownerSigner = await impersonate(owner, ether("1"));
 
     // Check initial value
     const initialMaxOperators = await dsm.getMaxOperatorsPerUnvetting();
@@ -100,7 +101,9 @@ describe("Integration: DSM keys unvetting", () => {
   });
 
   it("Should allow stranger to unvet keys with valid guardian signature", async () => {
-    // Create new guardian with known private key
+    const { nor } = ctx.contracts;
+
+    // Create new guardian with known (arbitrary) private key
     const guardian = new ethers.Wallet(GUARDIAN_PRIVATE_KEY).address;
 
     // Set single guardian
@@ -109,6 +112,7 @@ describe("Integration: DSM keys unvetting", () => {
     // Prepare unvet parameters
     const stakingModuleId = 1;
     const operatorId = 0n;
+    const vettedSigningKeysCount = 1n;
     const blockNumber = await time.latestBlock();
     const blockHash = (await ethers.provider.getBlock(blockNumber))!.hash!;
     const nonce = await ctx.contracts.stakingRouter.getStakingModuleNonce(stakingModuleId);
@@ -117,7 +121,7 @@ describe("Integration: DSM keys unvetting", () => {
     const nodeOperatorIds = ethers.solidityPacked(["uint64"], [operatorId]);
 
     // Pack vetted signing keys counts into bytes (16 bytes per count)
-    const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [1]);
+    const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [vettedSigningKeysCount]);
 
     // Generate valid guardian signature
     const unvetMessage = new DSMUnvetMessage(
@@ -131,15 +135,32 @@ describe("Integration: DSM keys unvetting", () => {
     const sig = await unvetMessage.sign(GUARDIAN_PRIVATE_KEY);
 
     // Stranger should be able to unvet with valid guardian signature
-    await dsm
+    // Get node operator state before unvetting
+    const nodeOperatorBefore = await nor.getNodeOperator(operatorId, true);
+    const totalVettedValidatorsBefore = nodeOperatorBefore.totalVettedValidators;
+    expect(totalVettedValidatorsBefore).to.be.not.equal(vettedSigningKeysCount);
+
+    // Unvet signing keys
+    const tx = await dsm
       .connect(stranger)
       .unvetSigningKeys(blockNumber, blockHash, stakingModuleId, nonce, nodeOperatorIds, vettedSigningKeysCounts, sig);
+
+    // Check events
+    const receipt = await tx.wait();
+    const unvetEvents = findEventsWithInterfaces(receipt!, "VettedSigningKeysCountChanged", [nor.interface]);
+    expect(unvetEvents.length).to.equal(1);
+    expect(unvetEvents[0].args.nodeOperatorId).to.equal(operatorId);
+    expect(unvetEvents[0].args.approvedValidatorsCount).to.equal(vettedSigningKeysCount);
+
+    // Verify node operator state after unvetting
+    const nodeOperatorAfter = await nor.getNodeOperator(operatorId, true);
+    expect(nodeOperatorAfter.totalVettedValidators).to.equal(vettedSigningKeysCount);
   });
 
   it("Should allow guardian to unvet signing keys directly", async () => {
     const { nor } = ctx.contracts;
 
-    // Create new guardian with known private key
+    // Create new guardian with known (arbitrary)private key
     const guardian = new ethers.Wallet(GUARDIAN_PRIVATE_KEY).address;
     const guardianSigner = await impersonate(guardian, ether("1"));
 
@@ -149,6 +170,7 @@ describe("Integration: DSM keys unvetting", () => {
     // Prepare unvet parameters
     const stakingModuleId = 1;
     const operatorId = 0n;
+    const vettedSigningKeysCount = 3n;
     const blockNumber = await time.latestBlock();
     const blockHash = (await ethers.provider.getBlock(blockNumber))!.hash!;
     const nonce = await ctx.contracts.stakingRouter.getStakingModuleNonce(stakingModuleId);
@@ -162,20 +184,27 @@ describe("Integration: DSM keys unvetting", () => {
     const nodeOperatorIds = ethers.solidityPacked(["uint64"], [operatorId]);
 
     // Pack vetted signing keys counts into bytes (16 bytes per count)
-    const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [1]);
+    const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [vettedSigningKeysCount]);
 
     // Guardian should be able to unvet directly without signature
-    await dsm
+    const tx = await dsm
       .connect(guardianSigner)
       .unvetSigningKeys(blockNumber, blockHash, stakingModuleId, nonce, nodeOperatorIds, vettedSigningKeysCounts, {
         r: ZeroHash,
         vs: ZeroHash,
       });
 
+    // Check events
+    const receipt = await tx.wait();
+    const unvetEvents = findEventsWithInterfaces(receipt!, "VettedSigningKeysCountChanged", [nor.interface]);
+    expect(unvetEvents.length).to.equal(1);
+    expect(unvetEvents[0].args.nodeOperatorId).to.equal(operatorId);
+    expect(unvetEvents[0].args.approvedValidatorsCount).to.equal(vettedSigningKeysCount);
+
     // Verify node operator state after unvetting
-    const nodeOperatorsAfter = await nor.getNodeOperator(operatorId, true);
-    expect(nodeOperatorsAfter.totalDepositedValidators).to.equal(totalDepositedValidatorsBefore);
-    expect(nodeOperatorsAfter.totalVettedValidators).to.equal(totalDepositedValidatorsBefore);
+    const nodeOperatorAfter = await nor.getNodeOperator(operatorId, true);
+    expect(nodeOperatorAfter.totalDepositedValidators).to.equal(totalDepositedValidatorsBefore);
+    expect(nodeOperatorAfter.totalVettedValidators).to.equal(vettedSigningKeysCount);
   });
 
   it("Should allow guardian to decrease vetted signing keys count", async () => {
@@ -204,19 +233,26 @@ describe("Integration: DSM keys unvetting", () => {
     const nodeOperatorIds = ethers.solidityPacked(["uint64"], [operatorId]);
 
     // Pack vetted signing keys counts into bytes (16 bytes per count)
-    const vettedSigningKeysCountsAfterUnvet = 4n;
+    const vettedSigningKeysCountsAfterUnvet = 3n;
     const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [vettedSigningKeysCountsAfterUnvet]);
 
     // Set single guardian
     await setSingleGuardian(ctx, stranger.address);
 
     // Guardian should be able to unvet directly without signature
-    await dsm
+    const tx = await dsm
       .connect(stranger)
       .unvetSigningKeys(blockNumber, blockHash, stakingModuleId, nonce, nodeOperatorIds, vettedSigningKeysCounts, {
         r: ZeroHash,
         vs: ZeroHash,
       });
+
+    // Check events
+    const receipt = await tx.wait();
+    const unvetEvents = findEventsWithInterfaces(receipt!, "VettedSigningKeysCountChanged", [nor.interface]);
+    expect(unvetEvents.length).to.equal(1);
+    expect(unvetEvents[0].args.nodeOperatorId).to.equal(operatorId);
+    expect(unvetEvents[0].args.approvedValidatorsCount).to.equal(vettedSigningKeysCountsAfterUnvet);
 
     // Verify node operator state after unvetting
     const nodeOperatorAfterUnvetting = await nor.getNodeOperator(operatorId, true);

--- a/test/integration/core/dsm-keys-unvetting.integration.ts
+++ b/test/integration/core/dsm-keys-unvetting.integration.ts
@@ -1,0 +1,225 @@
+import { expect } from "chai";
+import { ZeroHash } from "ethers";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+import { DepositSecurityModule } from "typechain-types";
+
+import { certainAddress, DSMUnvetMessage, ether, impersonate } from "lib";
+import { getProtocolContext, ProtocolContext } from "lib/protocol";
+import { setSingleGuardian } from "lib/protocol/helpers/dsm";
+import { norAddNodeOperator, norAddOperatorKeys, norSetOperatorStakingLimit } from "lib/protocol/helpers/nor";
+
+import { Snapshot } from "test/suite";
+
+const GUARDIAN_PRIVATE_KEY = "0x516b8a7d9290502f5661da81f0cf43893e3d19cb9aea3c426cfb36e8186e9c09";
+
+describe("Integration: DSM keys unvetting", () => {
+  let ctx: ProtocolContext;
+  let stranger: HardhatEthersSigner;
+  let dsm: DepositSecurityModule;
+
+  let snapshot: string;
+  let originalState: string;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+    dsm = ctx.contracts.depositSecurityModule;
+
+    snapshot = await Snapshot.take();
+
+    [stranger] = await ethers.getSigners();
+
+    DSMUnvetMessage.setMessagePrefix(await dsm.UNVET_MESSAGE_PREFIX());
+  });
+
+  beforeEach(async () => (originalState = await Snapshot.take()));
+
+  afterEach(async () => await Snapshot.restore(originalState));
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  it("Should allow owner to set max operators per unvetting", async () => {
+    const owner = await dsm.getOwner();
+    const ownerSigner = await impersonate(owner);
+
+    // Check initial value
+    const initialMaxOperators = await dsm.getMaxOperatorsPerUnvetting();
+
+    // Should revert when stranger tries to set value
+    await expect(dsm.connect(stranger).setMaxOperatorsPerUnvetting(1)).to.be.revertedWithCustomError(dsm, "NotAnOwner");
+
+    // Owner should be able to set new value
+    await dsm.connect(ownerSigner).setMaxOperatorsPerUnvetting(1);
+    expect(await dsm.getMaxOperatorsPerUnvetting()).to.equal(1);
+
+    // Reset to initial value
+    await dsm.connect(ownerSigner).setMaxOperatorsPerUnvetting(initialMaxOperators);
+  });
+
+  it("Should revert when stranger tries to unvet keys without valid guardian signature", async () => {
+    const stakingModuleId = 1;
+    const operatorId = 0n;
+    const blockNumber = await time.latestBlock();
+    const blockHash = (await ethers.provider.getBlock(blockNumber))!.hash!;
+    const nonce = await ctx.contracts.stakingRouter.getStakingModuleNonce(stakingModuleId);
+
+    // Pack operator IDs into bytes (8 bytes per ID)
+    const nodeOperatorIds = ethers.solidityPacked(["uint64"], [operatorId]);
+
+    // Pack vetted signing keys counts into bytes (16 bytes per count)
+    const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [1]);
+
+    // Create signature with non-guardian private key
+    const nonGuardianPrivateKey = "0x" + "1".repeat(64);
+    const unvetMessage = new DSMUnvetMessage(
+      blockNumber,
+      blockHash,
+      stakingModuleId,
+      Number(nonce),
+      nodeOperatorIds,
+      vettedSigningKeysCounts,
+    );
+    const sig = await unvetMessage.sign(nonGuardianPrivateKey);
+
+    await expect(
+      dsm
+        .connect(stranger)
+        .unvetSigningKeys(
+          blockNumber,
+          blockHash,
+          stakingModuleId,
+          nonce,
+          nodeOperatorIds,
+          vettedSigningKeysCounts,
+          sig,
+        ),
+    ).to.be.revertedWithCustomError(dsm, "InvalidSignature");
+  });
+
+  it("Should allow stranger to unvet keys with valid guardian signature", async () => {
+    // Create new guardian with known private key
+    const guardian = new ethers.Wallet(GUARDIAN_PRIVATE_KEY).address;
+
+    // Set single guardian
+    await setSingleGuardian(ctx, guardian);
+
+    // Prepare unvet parameters
+    const stakingModuleId = 1;
+    const operatorId = 0n;
+    const blockNumber = await time.latestBlock();
+    const blockHash = (await ethers.provider.getBlock(blockNumber))!.hash!;
+    const nonce = await ctx.contracts.stakingRouter.getStakingModuleNonce(stakingModuleId);
+
+    // Pack operator IDs into bytes (8 bytes per ID)
+    const nodeOperatorIds = ethers.solidityPacked(["uint64"], [operatorId]);
+
+    // Pack vetted signing keys counts into bytes (16 bytes per count)
+    const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [1]);
+
+    // Generate valid guardian signature
+    const unvetMessage = new DSMUnvetMessage(
+      blockNumber,
+      blockHash,
+      stakingModuleId,
+      Number(nonce),
+      nodeOperatorIds,
+      vettedSigningKeysCounts,
+    );
+    const sig = await unvetMessage.sign(GUARDIAN_PRIVATE_KEY);
+
+    // Stranger should be able to unvet with valid guardian signature
+    await dsm
+      .connect(stranger)
+      .unvetSigningKeys(blockNumber, blockHash, stakingModuleId, nonce, nodeOperatorIds, vettedSigningKeysCounts, sig);
+  });
+
+  it("Should allow guardian to unvet signing keys directly", async () => {
+    const { nor } = ctx.contracts;
+
+    // Create new guardian with known private key
+    const guardian = new ethers.Wallet(GUARDIAN_PRIVATE_KEY).address;
+    const guardianSigner = await impersonate(guardian, ether("1"));
+
+    // Set single guardian
+    await setSingleGuardian(ctx, guardian);
+
+    // Prepare unvet parameters
+    const stakingModuleId = 1;
+    const operatorId = 0n;
+    const blockNumber = await time.latestBlock();
+    const blockHash = (await ethers.provider.getBlock(blockNumber))!.hash!;
+    const nonce = await ctx.contracts.stakingRouter.getStakingModuleNonce(stakingModuleId);
+
+    // Get node operator state before unvetting
+    const nodeOperatorsBefore = await nor.getNodeOperator(operatorId, true);
+    const totalDepositedValidatorsBefore = nodeOperatorsBefore.totalDepositedValidators;
+    expect(totalDepositedValidatorsBefore).to.be.gte(1n);
+
+    // Pack operator IDs into bytes (8 bytes per ID)
+    const nodeOperatorIds = ethers.solidityPacked(["uint64"], [operatorId]);
+
+    // Pack vetted signing keys counts into bytes (16 bytes per count)
+    const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [1]);
+
+    // Guardian should be able to unvet directly without signature
+    await dsm
+      .connect(guardianSigner)
+      .unvetSigningKeys(blockNumber, blockHash, stakingModuleId, nonce, nodeOperatorIds, vettedSigningKeysCounts, {
+        r: ZeroHash,
+        vs: ZeroHash,
+      });
+
+    // Verify node operator state after unvetting
+    const nodeOperatorsAfter = await nor.getNodeOperator(operatorId, true);
+    expect(nodeOperatorsAfter.totalDepositedValidators).to.equal(totalDepositedValidatorsBefore);
+    expect(nodeOperatorsAfter.totalVettedValidators).to.equal(totalDepositedValidatorsBefore);
+  });
+
+  it("Should allow guardian to decrease vetted signing keys count", async () => {
+    const { nor } = ctx.contracts;
+
+    // Add node operator and signing keys
+    const stakingModuleId = 1;
+    const rewardAddress = certainAddress("rewardAddress");
+    const operatorId = await norAddNodeOperator(ctx, {
+      name: "test",
+      rewardAddress,
+    });
+
+    // Add signing keys
+    await norAddOperatorKeys(ctx, { operatorId, keysToAdd: 10n });
+
+    // Set staking limit to 8
+    await norSetOperatorStakingLimit(ctx, { operatorId, limit: 8n });
+
+    // Prepare unvet parameters
+    const blockNumber = await time.latestBlock();
+    const blockHash = (await ethers.provider.getBlock(blockNumber))!.hash!;
+    const nonce = await ctx.contracts.stakingRouter.getStakingModuleNonce(stakingModuleId);
+
+    // Pack operator IDs into bytes (8 bytes per ID)
+    const nodeOperatorIds = ethers.solidityPacked(["uint64"], [operatorId]);
+
+    // Pack vetted signing keys counts into bytes (16 bytes per count)
+    const vettedSigningKeysCountsAfterUnvet = 4n;
+    const vettedSigningKeysCounts = ethers.solidityPacked(["uint128"], [vettedSigningKeysCountsAfterUnvet]);
+
+    // Set single guardian
+    await setSingleGuardian(ctx, stranger.address);
+
+    // Guardian should be able to unvet directly without signature
+    await dsm
+      .connect(stranger)
+      .unvetSigningKeys(blockNumber, blockHash, stakingModuleId, nonce, nodeOperatorIds, vettedSigningKeysCounts, {
+        r: ZeroHash,
+        vs: ZeroHash,
+      });
+
+    // Verify node operator state after unvetting
+    const nodeOperatorAfterUnvetting = await nor.getNodeOperator(operatorId, true);
+    expect(nodeOperatorAfterUnvetting.totalVettedValidators).to.equal(vettedSigningKeysCountsAfterUnvet);
+  });
+});

--- a/test/integration/core/dsm-pause-deposits.integration.ts
+++ b/test/integration/core/dsm-pause-deposits.integration.ts
@@ -61,7 +61,7 @@ describe("Integration: DSM pause deposits", () => {
   async function ownerUnpauseDeposits() {
     expect(await dsm.isDepositsPaused()).to.be.true;
     const owner = await dsm.getOwner();
-    const ownerSigner = await impersonate(owner);
+    const ownerSigner = await impersonate(owner, ether("1"));
 
     const unpauseDepositTx = await dsm.connect(ownerSigner).unpauseDeposits();
 
@@ -84,7 +84,7 @@ describe("Integration: DSM pause deposits", () => {
   });
 
   it("Should allow stranger to pause deposits with guardian signature", async () => {
-    // Create new guardian with known private key
+    // Just an arbitrary account for using in tests
     const guardianPrivateKey = "0x516b8a7d9290502f5661da81f0cf43893e3d19cb9aea3c426cfb36e8186e9c09";
     const guardian = new ethers.Wallet(guardianPrivateKey).address;
 

--- a/test/integration/core/dsm-pause-deposits.integration.ts
+++ b/test/integration/core/dsm-pause-deposits.integration.ts
@@ -1,0 +1,146 @@
+import { expect } from "chai";
+import { ZeroHash } from "ethers";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { mine, time } from "@nomicfoundation/hardhat-network-helpers";
+
+import { DepositSecurityModule } from "typechain-types";
+
+import { DSMPauseMessage, ether, findEventsWithInterfaces, impersonate } from "lib";
+import { getProtocolContext, ProtocolContext } from "lib/protocol";
+import { setSingleGuardian } from "lib/protocol/helpers/dsm";
+
+import { Snapshot } from "test/suite";
+
+describe("Integration: DSM pause deposits", () => {
+  let ctx: ProtocolContext;
+  let stranger: HardhatEthersSigner;
+  let dsm: DepositSecurityModule;
+
+  let snapshot: string;
+  let originalState: string;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+    dsm = ctx.contracts.depositSecurityModule;
+
+    snapshot = await Snapshot.take();
+
+    [stranger] = await ethers.getSigners();
+
+    DSMPauseMessage.setMessagePrefix(await dsm.PAUSE_MESSAGE_PREFIX());
+  });
+
+  beforeEach(async () => (originalState = await Snapshot.take()));
+
+  afterEach(async () => await Snapshot.restore(originalState));
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  async function pauseDeposits(
+    pauser: HardhatEthersSigner,
+    blockNumber: bigint,
+    sig: DepositSecurityModule.SignatureStruct,
+    guardian: string,
+  ) {
+    expect(await dsm.isDepositsPaused()).to.be.false;
+
+    const pauseDepositTx = await dsm.connect(pauser).pauseDeposits(blockNumber, sig);
+
+    const receipt = await pauseDepositTx.wait();
+    const depositsPausedEvents = findEventsWithInterfaces(receipt!, "DepositsPaused", [dsm.interface]);
+
+    expect(depositsPausedEvents.length).to.equal(1);
+    expect(depositsPausedEvents[0].args.guardian).to.equal(guardian);
+    expect(await dsm.isDepositsPaused()).to.be.true;
+
+    return pauseDepositTx;
+  }
+
+  async function ownerUnpauseDeposits() {
+    expect(await dsm.isDepositsPaused()).to.be.true;
+    const owner = await dsm.getOwner();
+    const ownerSigner = await impersonate(owner);
+
+    const unpauseDepositTx = await dsm.connect(ownerSigner).unpauseDeposits();
+
+    const receipt = await unpauseDepositTx.wait();
+    const depositsUnpausedEvents = findEventsWithInterfaces(receipt!, "DepositsUnpaused", [dsm.interface]);
+
+    expect(depositsUnpausedEvents.length).to.equal(1);
+    expect(await dsm.isDepositsPaused()).to.be.false;
+
+    return unpauseDepositTx;
+  }
+
+  it("Should allow guardian to pause deposits and owner to unpause", async () => {
+    const guardian = (await dsm.getGuardians())[0];
+    const guardianSigner = await impersonate(guardian, ether("1"));
+
+    const blockNumber = await time.latestBlock();
+    await pauseDeposits(guardianSigner, BigInt(blockNumber), { r: ZeroHash, vs: ZeroHash }, guardian);
+    await ownerUnpauseDeposits();
+  });
+
+  it("Should allow stranger to pause deposits with guardian signature", async () => {
+    // Create new guardian with known private key
+    const guardianPrivateKey = "0x516b8a7d9290502f5661da81f0cf43893e3d19cb9aea3c426cfb36e8186e9c09";
+    const guardian = new ethers.Wallet(guardianPrivateKey).address;
+
+    // Set single guardian
+    await setSingleGuardian(ctx, guardian);
+
+    // Generate signature
+    const blockNumber = await time.latestBlock();
+    const pauseMessage = new DSMPauseMessage(blockNumber);
+    const sig = await pauseMessage.sign(guardianPrivateKey);
+
+    // Pause and unpause
+    await pauseDeposits(stranger, BigInt(blockNumber), sig, guardian);
+    await ownerUnpauseDeposits();
+  });
+
+  it("Should revert when trying to pause deposits with expired block number", async () => {
+    const guardian = (await dsm.getGuardians())[0];
+    const guardianSigner = await impersonate(guardian, ether("1"));
+
+    const pauseIntentValidityPeriodBlocks = await dsm.getPauseIntentValidityPeriodBlocks();
+    let currentBlock = BigInt(await time.latestBlock());
+    if (currentBlock <= pauseIntentValidityPeriodBlocks) {
+      await mine(Number(pauseIntentValidityPeriodBlocks) + 1);
+      currentBlock = BigInt(await time.latestBlock());
+    }
+    const expiredBlockNumber = currentBlock - pauseIntentValidityPeriodBlocks - 1n;
+
+    await expect(
+      dsm.connect(guardianSigner).pauseDeposits(expiredBlockNumber, {
+        r: ZeroHash,
+        vs: ZeroHash,
+      }),
+    ).to.be.revertedWithCustomError(dsm, "PauseIntentExpired");
+  });
+
+  it("Should revert when stranger tries to pause deposits without valid guardian signature", async () => {
+    expect(await dsm.isDepositsPaused()).to.equal(false);
+
+    // Try with empty signature
+    await expect(
+      dsm.connect(stranger).pauseDeposits(await time.latestBlock(), {
+        r: ZeroHash,
+        vs: ZeroHash,
+      }),
+    ).to.be.revertedWith("ECDSA: invalid signature");
+
+    // Try with non-guardian signature
+    const blockNumber = await time.latestBlock();
+    const nonGuardianPrivateKey = "0x" + "1".repeat(64);
+    const pauseMessage = new DSMPauseMessage(blockNumber);
+    const sig = pauseMessage.sign(nonGuardianPrivateKey);
+
+    await expect(dsm.connect(stranger).pauseDeposits(blockNumber, sig)).to.be.revertedWithCustomError(
+      dsm,
+      "InvalidSignature",
+    );
+  });
+});

--- a/test/integration/core/el-rewards.integration.ts
+++ b/test/integration/core/el-rewards.integration.ts
@@ -1,0 +1,92 @@
+import { expect } from "chai";
+import { ContractTransactionReceipt } from "ethers";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+import { ether } from "lib";
+import { getProtocolContext, ProtocolContext } from "lib/protocol";
+
+import { Snapshot } from "test/suite";
+
+describe("EL rewards distribution", () => {
+  let ctx: ProtocolContext;
+  let snapshot: string;
+  let stranger: HardhatEthersSigner;
+
+  const REWARD_AMOUNT = ether("1");
+
+  before(async () => {
+    ctx = await getProtocolContext();
+    [stranger] = await ethers.getSigners();
+    snapshot = await Snapshot.take();
+  });
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  it("Should have correct initial values", async () => {
+    const { lido, locator, elRewardsVault } = ctx.contracts;
+
+    expect(await elRewardsVault.LIDO()).to.equal(lido.address);
+    expect(await elRewardsVault.TREASURY()).to.equal(await locator.treasury());
+
+    if (!ctx.isScratch) {
+      expect(await lido.getTotalELRewardsCollected()).to.be.gt(0n);
+    }
+    expect(await locator.elRewardsVault()).to.equal(elRewardsVault.address);
+  });
+
+  it("Should emit event when receiving ETH", async () => {
+    const { elRewardsVault } = ctx.contracts;
+
+    const balanceBefore = await ethers.provider.getBalance(elRewardsVault.address);
+
+    const tx = await stranger.sendTransaction({
+      to: elRewardsVault.address,
+      value: REWARD_AMOUNT,
+    });
+    const receipt = (await tx.wait()) as ContractTransactionReceipt;
+
+    const balanceAfter = await ethers.provider.getBalance(elRewardsVault.address);
+
+    expect(balanceAfter - balanceBefore).to.equal(REWARD_AMOUNT);
+
+    const ethReceivedEvent = ctx.getEvents(receipt, "ETHReceived")[0];
+    expect(ethReceivedEvent?.args[0]).to.equal(REWARD_AMOUNT);
+  });
+
+  it("Should not allow stranger to receive EL rewards", async () => {
+    const { lido, locator } = ctx.contracts;
+
+    expect(await locator.elRewardsVault()).to.not.equal(stranger.address);
+    await expect(lido.connect(stranger).receiveELRewards({ value: REWARD_AMOUNT })).to.be.reverted;
+  });
+
+  it("receiveELRewards called by EL Rewards Vault moves rewards to Lido", async () => {
+    const { lido, elRewardsVault } = ctx.contracts;
+
+    const vaultBalanceBefore = await ethers.provider.getBalance(elRewardsVault.address);
+    await stranger.sendTransaction({
+      to: elRewardsVault.address,
+      value: REWARD_AMOUNT,
+    });
+    const vaultBalanceAfter = await ethers.provider.getBalance(elRewardsVault.address);
+    expect(vaultBalanceAfter - vaultBalanceBefore).to.equal(REWARD_AMOUNT);
+
+    const lidoBalanceBefore = await ethers.provider.getBalance(lido.address);
+    const totalRewardsCollectedBefore = await lido.getTotalELRewardsCollected();
+
+    const elRewardsVaultSigner = await ethers.getImpersonatedSigner(elRewardsVault.address);
+    const tx = await lido.connect(elRewardsVaultSigner).receiveELRewards({ value: REWARD_AMOUNT });
+    const receipt = (await tx.wait()) as ContractTransactionReceipt;
+
+    const elRewardsReceivedEvents = ctx.getEvents(receipt, "ELRewardsReceived");
+    expect(elRewardsReceivedEvents).to.have.length(1);
+    expect(elRewardsReceivedEvents[0].args[0]).to.equal(REWARD_AMOUNT);
+
+    expect(await lido.getTotalELRewardsCollected()).to.equal(totalRewardsCollectedBefore + REWARD_AMOUNT);
+    const elRewardsVaultBalanceAfter = await ethers.provider.getBalance(elRewardsVault.address);
+    expect(elRewardsVaultBalanceAfter).to.equal(vaultBalanceAfter - REWARD_AMOUNT - receipt.gasUsed * receipt.gasPrice);
+    expect(await ethers.provider.getBalance(lido.address)).to.equal(lidoBalanceBefore + REWARD_AMOUNT);
+  });
+});

--- a/test/integration/core/el-rewards.integration.ts
+++ b/test/integration/core/el-rewards.integration.ts
@@ -7,9 +7,9 @@ import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 import { ether } from "lib";
 import { getProtocolContext, ProtocolContext } from "lib/protocol";
 
-import { Snapshot } from "test/suite";
+import { bailOnFailure, Snapshot } from "test/suite";
 
-describe("EL rewards distribution", () => {
+describe("Scenario: EL rewards distribution", () => {
   let ctx: ProtocolContext;
   let snapshot: string;
   let stranger: HardhatEthersSigner;
@@ -23,6 +23,8 @@ describe("EL rewards distribution", () => {
   });
 
   after(async () => await Snapshot.restore(snapshot));
+
+  beforeEach(bailOnFailure);
 
   it("Should have correct initial values", async () => {
     const { lido, locator, elRewardsVault } = ctx.contracts;

--- a/test/integration/core/hash-consensus.integration.ts
+++ b/test/integration/core/hash-consensus.integration.ts
@@ -18,12 +18,16 @@ import { Snapshot, ZERO_HASH } from "test/suite";
 
 import { HashConsensus } from "../../../typechain-types";
 
+const UINT64_MAX = 2n ** 64n - 1n;
+
 describe("Hash consensus negative scenarios", () => {
   let ctx: ProtocolContext;
-  let snapshot: string;
   let stranger: HardhatEthersSigner;
   let hashConsensus: HashConsensus;
   let agent: HardhatEthersSigner;
+
+  let snapshot: string;
+  let originalState: string;
 
   before(async () => {
     ctx = await getProtocolContext();
@@ -34,6 +38,10 @@ describe("Hash consensus negative scenarios", () => {
   });
 
   after(async () => await Snapshot.restore(snapshot));
+
+  beforeEach(async () => (originalState = await Snapshot.take()));
+
+  afterEach(async () => await Snapshot.restore(originalState));
 
   it("Should not allow updating initial epoch after initialization", async () => {
     await expect(hashConsensus.connect(agent).updateInitialEpoch(1)).to.be.revertedWithCustomError(
@@ -189,7 +197,7 @@ describe("Hash consensus negative scenarios", () => {
 
     // Test numeric overflow
     await expect(
-      hashConsensus.connect(memberSigner).submitReport(2n ** 64n, reportHash, consensusVersion),
+      hashConsensus.connect(memberSigner).submitReport(UINT64_MAX + 1n, reportHash, consensusVersion),
     ).to.be.revertedWithCustomError(hashConsensus, "NumericOverflow");
 
     // Test empty report

--- a/test/integration/core/hash-consensus.integration.ts
+++ b/test/integration/core/hash-consensus.integration.ts
@@ -1,0 +1,252 @@
+import { expect } from "chai";
+import { ZeroAddress } from "ethers";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+import { ether, impersonate } from "lib";
+import {
+  calcReportDataHash,
+  getProtocolContext,
+  getReportDataItems,
+  ProtocolContext,
+  report,
+  waitNextAvailableReportTime,
+} from "lib/protocol";
+
+import { Snapshot, ZERO_HASH } from "test/suite";
+
+import { HashConsensus } from "../../../typechain-types";
+
+describe("Hash consensus negative scenarios", () => {
+  let ctx: ProtocolContext;
+  let snapshot: string;
+  let stranger: HardhatEthersSigner;
+  let hashConsensus: HashConsensus;
+  let agent: HardhatEthersSigner;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+    hashConsensus = ctx.contracts.hashConsensus;
+    [stranger] = await ethers.getSigners();
+    agent = await ctx.getSigner("agent");
+    snapshot = await Snapshot.take();
+  });
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  it("Should not allow updating initial epoch after initialization", async () => {
+    await expect(hashConsensus.connect(agent).updateInitialEpoch(1)).to.be.revertedWithCustomError(
+      hashConsensus,
+      "InitialEpochAlreadyArrived",
+    );
+  });
+
+  it("Should validate frame config parameters", async () => {
+    // Grant MANAGE_FRAME_CONFIG_ROLE to stranger
+    const MANAGE_FRAME_CONFIG_ROLE = await hashConsensus.MANAGE_FRAME_CONFIG_ROLE();
+    await hashConsensus.connect(agent).grantRole(MANAGE_FRAME_CONFIG_ROLE, stranger.address);
+
+    // Get slots per epoch from chain config
+    const [slotsPerEpoch] = await hashConsensus.getChainConfig();
+
+    // Test epochs per frame cannot be zero
+    await expect(hashConsensus.connect(stranger).setFrameConfig(0, 1)).to.be.revertedWithCustomError(
+      hashConsensus,
+      "EpochsPerFrameCannotBeZero",
+    );
+
+    // Test fast lane period cannot be longer than frame
+    const epochsPerFrame = 2n;
+    await expect(
+      hashConsensus.connect(stranger).setFrameConfig(epochsPerFrame, epochsPerFrame * slotsPerEpoch + 1n),
+    ).to.be.revertedWithCustomError(hashConsensus, "FastLanePeriodCannotBeLongerThanFrame");
+  });
+
+  it("Should validate fast lane length slots parameter", async () => {
+    // Grant MANAGE_FAST_LANE_CONFIG_ROLE to stranger
+    const MANAGE_FAST_LANE_CONFIG_ROLE = await hashConsensus.MANAGE_FAST_LANE_CONFIG_ROLE();
+    await hashConsensus.connect(agent).grantRole(MANAGE_FAST_LANE_CONFIG_ROLE, stranger.address);
+
+    // Get chain config and frame config
+    const [slotsPerEpoch] = await hashConsensus.getChainConfig();
+    const [, epochsPerFrame] = await hashConsensus.getFrameConfig();
+
+    // Test fast lane period cannot be longer than frame
+    await expect(
+      hashConsensus.connect(stranger).setFastLaneLengthSlots(epochsPerFrame * slotsPerEpoch + 1n),
+    ).to.be.revertedWithCustomError(hashConsensus, "FastLanePeriodCannotBeLongerThanFrame");
+  });
+
+  it("Should validate member addition", async () => {
+    // Grant MANAGE_MEMBERS_AND_QUORUM_ROLE to stranger
+    const MANAGE_MEMBERS_AND_QUORUM_ROLE = await hashConsensus.MANAGE_MEMBERS_AND_QUORUM_ROLE();
+    await hashConsensus.connect(agent).grantRole(MANAGE_MEMBERS_AND_QUORUM_ROLE, stranger.address);
+
+    const currentQuorum = await hashConsensus.getQuorum();
+    const [members] = await hashConsensus.getMembers();
+
+    // Test cannot add duplicate member
+    await expect(hashConsensus.connect(stranger).addMember(members[0], currentQuorum)).to.be.revertedWithCustomError(
+      hashConsensus,
+      "DuplicateMember",
+    );
+
+    // Test cannot add zero address
+    await expect(hashConsensus.connect(stranger).addMember(ZeroAddress, currentQuorum)).to.be.revertedWithCustomError(
+      hashConsensus,
+      "AddressCannotBeZero",
+    );
+
+    // Test quorum must be greater than half members + 1
+    const requiredQuorum = Math.floor((members.length + 1) / 2) + 1;
+    await expect(hashConsensus.connect(stranger).addMember(stranger.address, requiredQuorum - 1))
+      .to.be.revertedWithCustomError(hashConsensus, "QuorumTooSmall")
+      .withArgs(requiredQuorum, requiredQuorum - 1);
+  });
+
+  it("Should validate member removal", async () => {
+    // Grant MANAGE_MEMBERS_AND_QUORUM_ROLE to stranger
+    const MANAGE_MEMBERS_AND_QUORUM_ROLE = await hashConsensus.MANAGE_MEMBERS_AND_QUORUM_ROLE();
+    await hashConsensus.connect(agent).grantRole(MANAGE_MEMBERS_AND_QUORUM_ROLE, stranger.address);
+
+    const [members] = await hashConsensus.getMembers();
+
+    // Test cannot remove non-member
+    await expect(hashConsensus.connect(stranger).removeMember(stranger.address, 1n)).to.be.revertedWithCustomError(
+      hashConsensus,
+      "NonMember",
+    );
+
+    // Test quorum must be greater than half members - 1
+    const requiredQuorum = Math.floor((members.length - 1) / 2) + 1; // -1 for the removed member
+    await expect(hashConsensus.connect(stranger).removeMember(members[0], requiredQuorum - 1))
+      .to.be.revertedWithCustomError(hashConsensus, "QuorumTooSmall")
+      .withArgs(requiredQuorum, requiredQuorum - 1);
+  });
+
+  it("Should validate quorum updates", async () => {
+    // Grant MANAGE_MEMBERS_AND_QUORUM_ROLE to stranger
+    const MANAGE_MEMBERS_AND_QUORUM_ROLE = await hashConsensus.MANAGE_MEMBERS_AND_QUORUM_ROLE();
+    await hashConsensus.connect(agent).grantRole(MANAGE_MEMBERS_AND_QUORUM_ROLE, stranger.address);
+
+    const [members] = await hashConsensus.getMembers();
+
+    // Test quorum must be greater than half members
+    const requiredQuorum = Math.floor(members.length / 2) + 1;
+    await expect(hashConsensus.connect(stranger).setQuorum(requiredQuorum - 1))
+      .to.be.revertedWithCustomError(hashConsensus, "QuorumTooSmall")
+      .withArgs(requiredQuorum, requiredQuorum - 1);
+  });
+
+  it("Should validate report processor updates", async () => {
+    // Grant MANAGE_REPORT_PROCESSOR_ROLE to stranger
+    const MANAGE_REPORT_PROCESSOR_ROLE = await hashConsensus.MANAGE_REPORT_PROCESSOR_ROLE();
+    await hashConsensus.connect(agent).grantRole(MANAGE_REPORT_PROCESSOR_ROLE, stranger.address);
+
+    const prevReportProcessor = await hashConsensus.getReportProcessor();
+
+    // Test cannot set zero address
+    await expect(hashConsensus.connect(stranger).setReportProcessor(ZeroAddress)).to.be.revertedWithCustomError(
+      hashConsensus,
+      "ReportProcessorCannotBeZero",
+    );
+
+    // Test cannot set same address
+    await expect(hashConsensus.connect(stranger).setReportProcessor(prevReportProcessor)).to.be.revertedWithCustomError(
+      hashConsensus,
+      "NewProcessorCannotBeTheSame",
+    );
+  });
+
+  it("Should validate report submission", async () => {
+    await waitNextAvailableReportTime(ctx);
+
+    const { accountingOracle } = ctx.contracts;
+
+    const consensusVersion = await accountingOracle.getConsensusVersion();
+    const contractVersion = await accountingOracle.getContractVersion();
+
+    const [members] = await hashConsensus.getMembers();
+    const member = members[0];
+    const memberSigner = await impersonate(member, ether("1"));
+
+    async function getLanesMembers() {
+      const [fastLaneMembers] = await hashConsensus.getFastLaneMembers();
+      const nonFastLaneMembers = members.filter((m) => !fastLaneMembers.includes(m));
+      return { fastLaneMembers, nonFastLaneMembers };
+    }
+
+    const { data: reportData } = await report(ctx, { clDiff: 1234567n, dryRun: true });
+
+    const items = getReportDataItems(reportData);
+    const reportHash = calcReportDataHash(items);
+
+    // Test cannot submit with invalid slot
+    await expect(
+      hashConsensus.connect(memberSigner).submitReport(0n, reportHash, consensusVersion),
+    ).to.be.revertedWithCustomError(hashConsensus, "InvalidSlot");
+
+    // Test numeric overflow
+    await expect(
+      hashConsensus.connect(memberSigner).submitReport(2n ** 64n, reportHash, consensusVersion),
+    ).to.be.revertedWithCustomError(hashConsensus, "NumericOverflow");
+
+    // Test empty report
+    await expect(
+      hashConsensus.connect(memberSigner).submitReport(1n, ZERO_HASH, consensusVersion),
+    ).to.be.revertedWithCustomError(hashConsensus, "EmptyReport");
+
+    // Test non-member cannot submit
+    await expect(
+      hashConsensus.connect(stranger).submitReport(1n, reportHash, consensusVersion),
+    ).to.be.revertedWithCustomError(hashConsensus, "NonMember");
+
+    // Test unexpected consensus version
+    await expect(hashConsensus.connect(memberSigner).submitReport(1n, reportHash, consensusVersion + 1n))
+      .to.be.revertedWithCustomError(hashConsensus, "UnexpectedConsensusVersion")
+      .withArgs(consensusVersion, consensusVersion + 1n);
+
+    // Test invalid slot
+    await expect(
+      hashConsensus.connect(memberSigner).submitReport(1n, reportHash, consensusVersion),
+    ).to.be.revertedWithCustomError(hashConsensus, "InvalidSlot");
+
+    // Test reaching consensus
+    const { refSlot } = await hashConsensus.getCurrentFrame();
+
+    const { fastLaneMembers } = await getLanesMembers();
+
+    const fastLaneMember = fastLaneMembers[0];
+    const fastLaneMemberSigner = await impersonate(fastLaneMember, ether("1"));
+
+    for (const m of fastLaneMembers) {
+      const mSigner = await impersonate(m, ether("1"));
+      await hashConsensus.connect(mSigner).submitReport(refSlot, reportHash, consensusVersion);
+    }
+
+    // Test duplicate report
+    await expect(
+      hashConsensus.connect(fastLaneMemberSigner).submitReport(refSlot, reportHash, consensusVersion),
+    ).to.be.revertedWithCustomError(hashConsensus, "DuplicateReport");
+
+    await accountingOracle.connect(memberSigner).submitReportData(reportData, contractVersion);
+
+    await expect(
+      hashConsensus.connect(fastLaneMemberSigner).submitReport(refSlot, reportHash, consensusVersion),
+    ).to.be.revertedWithCustomError(hashConsensus, "ConsensusReportAlreadyProcessing");
+
+    await waitNextAvailableReportTime(ctx);
+
+    const { nonFastLaneMembers } = await getLanesMembers();
+    expect(nonFastLaneMembers.length).to.be.gt(0);
+
+    // Test non-fast lane member cannot report within fast lane interval
+    const { refSlot: newRefSlot } = await hashConsensus.getCurrentFrame();
+    await expect(
+      hashConsensus
+        .connect(await impersonate(nonFastLaneMembers[0], ether("1")))
+        .submitReport(newRefSlot, reportHash, consensusVersion),
+    ).to.be.revertedWithCustomError(hashConsensus, "NonFastLaneMemberCannotReportWithinFastLaneInterval");
+  });
+});

--- a/test/integration/core/node-operators-flow.integration.ts
+++ b/test/integration/core/node-operators-flow.integration.ts
@@ -1,0 +1,347 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { certainAddress, ether, findEventsWithInterfaces, impersonate } from "lib";
+import { getProtocolContext, ProtocolContext } from "lib/protocol";
+import { randomPubkeys, randomSignatures } from "lib/protocol/helpers/nor";
+
+import { Snapshot } from "test/suite";
+
+type NodeOperatorState = {
+  active: boolean;
+  name: string;
+  rewardAddress: string;
+  totalVettedValidators: bigint;
+  totalExitedValidators: bigint;
+  totalAddedValidators: bigint;
+  totalDepositedValidators: bigint;
+};
+
+type NodeOperatorSummary = {
+  targetLimitMode: bigint;
+  targetValidatorsCount: bigint;
+  stuckValidatorsCount: bigint;
+  refundedValidatorsCount: bigint;
+  stuckPenaltyEndTimestamp: bigint;
+  totalExitedValidators: bigint;
+  totalDepositedValidators: bigint;
+  depositableValidatorsCount: bigint;
+};
+
+function verifyNodeOperatorStateChanges(
+  nodeOperatorAfter: NodeOperatorState,
+  nodeOperatorBefore: NodeOperatorState,
+  expectedChanges: Partial<NodeOperatorState & { addedValidators: bigint }> = {},
+) {
+  expect(nodeOperatorAfter.totalExitedValidators).to.equal(nodeOperatorBefore.totalExitedValidators);
+  expect(nodeOperatorAfter.totalAddedValidators).to.equal(
+    nodeOperatorBefore.totalAddedValidators + (expectedChanges.addedValidators || 0n),
+  );
+  expect(nodeOperatorAfter.totalDepositedValidators).to.equal(nodeOperatorBefore.totalDepositedValidators);
+  expect(nodeOperatorAfter.name).to.equal(nodeOperatorBefore.name);
+  expect(nodeOperatorAfter.rewardAddress).to.equal(nodeOperatorBefore.rewardAddress);
+  expect(nodeOperatorAfter.active).to.equal(expectedChanges.active ?? nodeOperatorBefore.active);
+  if (expectedChanges.totalVettedValidators !== undefined) {
+    expect(nodeOperatorAfter.totalVettedValidators).to.equal(expectedChanges.totalVettedValidators);
+  } else {
+    expect(nodeOperatorAfter.totalVettedValidators).to.equal(nodeOperatorBefore.totalVettedValidators);
+  }
+}
+
+function verifyNodeOperatorSummaryStateChanges(
+  summaryAfter: NodeOperatorSummary,
+  summaryBefore: NodeOperatorSummary,
+  expectedChanges: Partial<NodeOperatorSummary> = {},
+) {
+  expect(summaryAfter.targetLimitMode).to.equal(summaryBefore.targetLimitMode);
+  expect(summaryAfter.targetValidatorsCount).to.equal(summaryBefore.targetValidatorsCount);
+  expect(summaryAfter.stuckValidatorsCount).to.equal(summaryBefore.stuckValidatorsCount);
+  expect(summaryAfter.refundedValidatorsCount).to.equal(summaryBefore.refundedValidatorsCount);
+  expect(summaryAfter.stuckPenaltyEndTimestamp).to.equal(summaryBefore.stuckPenaltyEndTimestamp);
+  expect(summaryAfter.totalExitedValidators).to.equal(summaryBefore.totalExitedValidators);
+  expect(summaryAfter.totalDepositedValidators).to.equal(summaryBefore.totalDepositedValidators);
+  if (expectedChanges.depositableValidatorsCount !== undefined) {
+    expect(summaryAfter.depositableValidatorsCount).to.equal(expectedChanges.depositableValidatorsCount);
+  } else {
+    expect(summaryAfter.depositableValidatorsCount).to.equal(summaryBefore.depositableValidatorsCount);
+  }
+}
+
+describe("Integration: Node operators flow", () => {
+  let ctx: ProtocolContext;
+
+  let snapshot: string;
+  let originalState: string;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+
+    snapshot = await Snapshot.take();
+
+    // Grant required roles
+    const votingSigner = await ctx.getSigner("voting");
+    const agentSigner = await ctx.getSigner("agent");
+
+    await ctx.contracts.stakingRouter
+      .connect(agentSigner)
+      .grantRole(
+        await ctx.contracts.stakingRouter.MANAGE_WITHDRAWAL_CREDENTIALS_ROLE(),
+        await votingSigner.getAddress(),
+      );
+
+    await ctx.contracts.acl
+      .connect(votingSigner)
+      .grantPermission(
+        await votingSigner.getAddress(),
+        ctx.contracts.nor.getAddress(),
+        ethers.keccak256(ethers.toUtf8Bytes("MANAGE_NODE_OPERATOR_ROLE")),
+      );
+  });
+
+  beforeEach(async () => (originalState = await Snapshot.take()));
+
+  afterEach(async () => await Snapshot.restore(originalState));
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  it("Should allow adding a node operator", async () => {
+    const { nor } = ctx.contracts;
+    const votingSigner = await ctx.getSigner("voting");
+    const rewardAddress = certainAddress("rewardAddress");
+    const operatorName = "new_node_operator";
+
+    // Get initial counts
+    let nodeOperatorsCountBefore = await nor.getNodeOperatorsCount();
+    let activeNodeOperatorsCountBefore = await nor.getActiveNodeOperatorsCount();
+
+    // Add node operator
+    const addTx = await nor.connect(votingSigner).addNodeOperator(operatorName, rewardAddress);
+
+    // Get counts after adding operator
+    let nodeOperatorsCountAfter = await nor.getNodeOperatorsCount();
+    let activeNodeOperatorsCountAfter = await nor.getActiveNodeOperatorsCount();
+
+    // Verify counts increased by 1
+    expect(nodeOperatorsCountAfter).to.equal(nodeOperatorsCountBefore + 1n);
+    expect(activeNodeOperatorsCountAfter).to.equal(activeNodeOperatorsCountBefore + 1n);
+
+    // Get new operator ID
+    const newOperatorId = nodeOperatorsCountBefore;
+
+    // Verify operator details
+    const operator = await nor.getNodeOperator(newOperatorId, true);
+    expect(operator.active).to.be.true;
+    expect(operator.name).to.equal(operatorName);
+    expect(operator.rewardAddress).to.equal(rewardAddress);
+    expect(operator.totalDepositedValidators).to.equal(0);
+    expect(operator.totalExitedValidators).to.equal(0);
+    expect(operator.totalAddedValidators).to.equal(0);
+    expect(operator.totalVettedValidators).to.equal(0);
+
+    // Verify operator summary
+    const summary = await nor.getNodeOperatorSummary(newOperatorId);
+    expect(summary.targetLimitMode).to.equal(0);
+    expect(summary.targetValidatorsCount).to.equal(0);
+    expect(summary.stuckValidatorsCount).to.equal(0);
+    expect(summary.refundedValidatorsCount).to.equal(0);
+    expect(summary.stuckPenaltyEndTimestamp).to.equal(0);
+    expect(summary.totalExitedValidators).to.equal(0);
+    expect(summary.totalDepositedValidators).to.equal(0);
+    expect(summary.depositableValidatorsCount).to.equal(0);
+
+    // Verify emitted event
+    const addReceipt = await addTx.wait();
+    const events = await findEventsWithInterfaces(addReceipt!, "NodeOperatorAdded", [nor.interface]);
+    expect(events.length).to.equal(1);
+    expect(events[0].args.nodeOperatorId).to.equal(newOperatorId);
+    expect(events[0].args.name).to.equal(operatorName);
+    expect(events[0].args.rewardAddress).to.equal(rewardAddress);
+    expect(events[0].args.stakingLimit).to.equal(0);
+
+    // Add signing keys to operator
+    const keysCount = 13n;
+    const pubkeys = randomPubkeys(Number(keysCount));
+    const signatures = randomSignatures(Number(keysCount));
+
+    // Get state before adding keys
+    let nonceBefore = await nor.getKeysOpIndex();
+    const totalSigningKeysCountBefore = await nor.getTotalSigningKeyCount(newOperatorId);
+    const unusedSigningKeysCountBefore = await nor.getUnusedSigningKeyCount(newOperatorId);
+    let nodeOperatorBefore = await nor.getNodeOperator(newOperatorId, true);
+    let nodeOperatorSummaryBefore = await nor.getNodeOperatorSummary(newOperatorId);
+
+    // Add signing keys
+    const rewardAddressSigner = await impersonate(rewardAddress, ether("1"));
+    const addKeysTx = await nor
+      .connect(rewardAddressSigner)
+      .addSigningKeysOperatorBH(newOperatorId, keysCount, pubkeys, signatures);
+
+    // Get state after adding keys
+    let nonceAfter = await nor.getKeysOpIndex();
+    const totalSigningKeysCountAfter = await nor.getTotalSigningKeyCount(newOperatorId);
+    const unusedSigningKeysCountAfter = await nor.getUnusedSigningKeyCount(newOperatorId);
+    let nodeOperatorAfter = await nor.getNodeOperator(newOperatorId, true);
+    let nodeOperatorSummaryAfter = await nor.getNodeOperatorSummary(newOperatorId);
+
+    // Verify state changes
+    expect(nonceAfter).to.not.equal(nonceBefore);
+    expect(totalSigningKeysCountAfter).to.equal(totalSigningKeysCountBefore + keysCount);
+    expect(unusedSigningKeysCountAfter).to.equal(unusedSigningKeysCountBefore + keysCount);
+
+    verifyNodeOperatorStateChanges(nodeOperatorAfter, nodeOperatorBefore, { addedValidators: keysCount });
+    verifyNodeOperatorSummaryStateChanges(nodeOperatorSummaryAfter, nodeOperatorSummaryBefore);
+
+    // Verify each signing key was added correctly
+    for (let i = 0; i < Number(keysCount); i++) {
+      const globalKeyIndex = Number(totalSigningKeysCountBefore) + i;
+      const signingKey = await nor.getSigningKey(newOperatorId, globalKeyIndex);
+
+      expect(signingKey.key).to.equal("0x" + Buffer.from(pubkeys.slice(i * 48, (i + 1) * 48)).toString("hex"));
+      expect(signingKey.depositSignature).to.equal(
+        "0x" + Buffer.from(signatures.slice(i * 96, (i + 1) * 96)).toString("hex"),
+      );
+      expect(signingKey.used).to.be.false;
+    }
+
+    // Verify events
+    await expect(addKeysTx)
+      .to.emit(nor, "TotalSigningKeysCountChanged")
+      .withArgs(newOperatorId, totalSigningKeysCountAfter);
+    await expect(addKeysTx).to.emit(nor, "KeysOpIndexSet").withArgs(nonceAfter);
+    await expect(addKeysTx).to.emit(nor, "NonceChanged").withArgs(nonceAfter);
+
+    // Get state before setting staking limit
+    nonceBefore = await nor.getKeysOpIndex();
+    nodeOperatorBefore = await nor.getNodeOperator(newOperatorId, true);
+    nodeOperatorSummaryBefore = await nor.getNodeOperatorSummary(newOperatorId);
+
+    // Verify staking limit
+    let newStakingLimit = await nor.getTotalSigningKeyCount(newOperatorId);
+    expect(newStakingLimit).to.not.equal(nodeOperatorBefore.totalVettedValidators, "invalid new staking limit");
+
+    // Set staking limit
+    const stakingLimitTx = await nor
+      .connect(await ctx.getSigner("voting"))
+      .setNodeOperatorStakingLimit(newOperatorId, newStakingLimit);
+
+    // Get state after setting staking limit
+    nonceAfter = await nor.getKeysOpIndex();
+    nodeOperatorAfter = await nor.getNodeOperator(newOperatorId, true);
+    nodeOperatorSummaryAfter = await nor.getNodeOperatorSummary(newOperatorId);
+
+    verifyNodeOperatorStateChanges(nodeOperatorAfter, nodeOperatorBefore, { totalVettedValidators: newStakingLimit });
+    verifyNodeOperatorSummaryStateChanges(nodeOperatorSummaryAfter, nodeOperatorSummaryBefore, {
+      depositableValidatorsCount: newStakingLimit,
+    });
+
+    // Verify events
+    await expect(stakingLimitTx).to.emit(nor, "VettedSigningKeysCountChanged").withArgs(newOperatorId, newStakingLimit);
+    await expect(stakingLimitTx).to.emit(nor, "KeysOpIndexSet").withArgs(nonceAfter);
+    await expect(stakingLimitTx).to.emit(nor, "NonceChanged").withArgs(nonceAfter);
+
+    // Get state before deactivating operator
+    nodeOperatorsCountBefore = await nor.getNodeOperatorsCount();
+    activeNodeOperatorsCountBefore = await nor.getActiveNodeOperatorsCount();
+    nodeOperatorBefore = await nor.getNodeOperator(newOperatorId, true);
+    nodeOperatorSummaryBefore = await nor.getNodeOperatorSummary(newOperatorId);
+
+    // Deactivate node operator
+    const deactivateTx = await nor.connect(votingSigner).deactivateNodeOperator(newOperatorId);
+
+    // Get state after deactivating operator
+    nodeOperatorsCountAfter = await nor.getNodeOperatorsCount();
+    activeNodeOperatorsCountAfter = await nor.getActiveNodeOperatorsCount();
+    nodeOperatorAfter = await nor.getNodeOperator(newOperatorId, true);
+    nodeOperatorSummaryAfter = await nor.getNodeOperatorSummary(newOperatorId);
+
+    // Verify operator counts
+    expect(nodeOperatorsCountAfter).to.equal(nodeOperatorsCountBefore);
+    expect(activeNodeOperatorsCountAfter).to.equal(activeNodeOperatorsCountBefore - 1n);
+
+    verifyNodeOperatorStateChanges(nodeOperatorAfter, nodeOperatorBefore, {
+      active: false,
+      totalVettedValidators: nodeOperatorBefore.totalDepositedValidators,
+    });
+    verifyNodeOperatorSummaryStateChanges(nodeOperatorSummaryAfter, nodeOperatorSummaryBefore, {
+      depositableValidatorsCount: 0n,
+    });
+
+    // Verify events
+    await expect(deactivateTx).to.emit(nor, "NodeOperatorActiveSet").withArgs(newOperatorId, false);
+
+    const deactivateReceipt = await deactivateTx.wait();
+    const deactivateEvents = await findEventsWithInterfaces(deactivateReceipt!, "NodeOperatorActiveSet", [
+      nor.interface,
+    ]);
+    expect(deactivateEvents.length).to.equal(1);
+    expect(deactivateEvents[0].args.nodeOperatorId).to.equal(newOperatorId);
+    expect(deactivateEvents[0].args.active).to.be.false;
+
+    // Get state before activating operator
+    nodeOperatorBefore = await nor.getNodeOperator(newOperatorId, true);
+    expect(nodeOperatorBefore.active).to.be.false;
+
+    nodeOperatorsCountBefore = await nor.getNodeOperatorsCount();
+    nodeOperatorSummaryBefore = await nor.getNodeOperatorSummary(newOperatorId);
+    activeNodeOperatorsCountBefore = await nor.getActiveNodeOperatorsCount();
+
+    // Activate node operator
+    const activateTx = await nor.connect(votingSigner).activateNodeOperator(newOperatorId);
+
+    // Get state after activating operator
+    nodeOperatorsCountAfter = await nor.getNodeOperatorsCount();
+    nodeOperatorSummaryAfter = await nor.getNodeOperatorSummary(newOperatorId);
+    activeNodeOperatorsCountAfter = await nor.getActiveNodeOperatorsCount();
+
+    // Verify operator counts
+    expect(nodeOperatorsCountAfter).to.equal(nodeOperatorsCountBefore);
+    expect(activeNodeOperatorsCountAfter).to.equal(activeNodeOperatorsCountBefore + 1n);
+
+    // Verify node operator state changes
+    nodeOperatorAfter = await nor.getNodeOperator(newOperatorId, true);
+    verifyNodeOperatorStateChanges(nodeOperatorAfter, nodeOperatorBefore, { active: true });
+    verifyNodeOperatorSummaryStateChanges(nodeOperatorSummaryAfter, nodeOperatorSummaryBefore);
+
+    // Verify events
+    await expect(activateTx).to.emit(nor, "NodeOperatorActiveSet").withArgs(newOperatorId, true);
+
+    const activateReceipt = await activateTx.wait();
+    const activateEvents = await findEventsWithInterfaces(activateReceipt!, "NodeOperatorActiveSet", [nor.interface]);
+    expect(activateEvents.length).to.equal(1);
+    expect(activateEvents[0].args.nodeOperatorId).to.equal(newOperatorId);
+    expect(activateEvents[0].args.active).to.be.true;
+
+    // Get state before setting staking limit
+    nonceBefore = await nor.getKeysOpIndex();
+    nodeOperatorBefore = await nor.getNodeOperator(newOperatorId, true);
+    nodeOperatorSummaryBefore = await nor.getNodeOperatorSummary(newOperatorId);
+
+    // Set new staking limit equal to total signing keys
+    newStakingLimit = await nor.getTotalSigningKeyCount(newOperatorId);
+    expect(newStakingLimit).to.not.equal(nodeOperatorBefore.totalVettedValidators, "Invalid new staking limit");
+
+    // Set staking limit
+    const setLimitTx = await nor
+      .connect(await ctx.getSigner("voting"))
+      .setNodeOperatorStakingLimit(newOperatorId, newStakingLimit);
+
+    // Get state after setting limit
+    nonceAfter = await nor.getKeysOpIndex();
+    nodeOperatorAfter = await nor.getNodeOperator(newOperatorId, true);
+    nodeOperatorSummaryAfter = await nor.getNodeOperatorSummary(newOperatorId);
+
+    verifyNodeOperatorStateChanges(nodeOperatorAfter, nodeOperatorBefore, { totalVettedValidators: newStakingLimit });
+    verifyNodeOperatorSummaryStateChanges(nodeOperatorSummaryAfter, nodeOperatorSummaryBefore, {
+      depositableValidatorsCount: newStakingLimit,
+    });
+
+    // Verify events
+    const setLimitReceipt = await setLimitTx.wait();
+    const setLimitEvents = await findEventsWithInterfaces(setLimitReceipt!, "VettedSigningKeysCountChanged", [
+      nor.interface,
+    ]);
+    expect(setLimitEvents.length).to.equal(1);
+    expect(setLimitEvents[0].args.nodeOperatorId).to.equal(newOperatorId);
+    expect(setLimitEvents[0].args.approvedValidatorsCount).to.equal(newStakingLimit);
+  });
+});

--- a/test/integration/core/staking-limits.integration.ts
+++ b/test/integration/core/staking-limits.integration.ts
@@ -15,6 +15,7 @@ describe("Staking limits", () => {
   let ctx: ProtocolContext;
   let lido: Lido;
   let snapshot: string;
+  let testSnapshot: string;
   let stranger: HardhatEthersSigner;
   let voting: HardhatEthersSigner;
 
@@ -25,6 +26,14 @@ describe("Staking limits", () => {
     voting = await ctx.getSigner("voting");
 
     snapshot = await Snapshot.take();
+  });
+
+  beforeEach(async () => {
+    testSnapshot = await Snapshot.take();
+  });
+
+  afterEach(async () => {
+    await Snapshot.restore(testSnapshot);
   });
 
   after(async () => await Snapshot.restore(snapshot));
@@ -187,11 +196,9 @@ describe("Staking limits", () => {
       const maxLimit = ether("1000");
       const limitPerBlock = ether("100");
 
-      const tx = await lido.connect(voting).setStakingLimit(maxLimit, limitPerBlock);
-      const receipt = await tx.wait();
-
-      expect(receipt?.logs.length).to.equal(1);
-      await expect(tx).to.emit(lido, "StakingLimitSet").withArgs(maxLimit, limitPerBlock);
+      await expect(lido.connect(voting).setStakingLimit(maxLimit, limitPerBlock))
+        .to.emit(lido, "StakingLimitSet")
+        .withArgs(maxLimit, limitPerBlock);
 
       const info = await lido.getStakeLimitFullInfo();
       expect(info.isStakingLimitSet).to.be.true;
@@ -204,11 +211,9 @@ describe("Staking limits", () => {
 
       const newMax = ether("2000");
       const newPerBlock = ether("200");
-      const tx = await lido.connect(voting).setStakingLimit(newMax, newPerBlock);
-      const receipt = await tx.wait();
-
-      expect(receipt?.logs.length).to.equal(1);
-      await expect(tx).to.emit(lido, "StakingLimitSet").withArgs(newMax, newPerBlock);
+      await expect(lido.connect(voting).setStakingLimit(newMax, newPerBlock))
+        .to.emit(lido, "StakingLimitSet")
+        .withArgs(newMax, newPerBlock);
 
       const info = await lido.getStakeLimitFullInfo();
       expect(info.isStakingLimitSet).to.be.true;
@@ -219,11 +224,7 @@ describe("Staking limits", () => {
       const limitPerBlock = ether("100");
       await lido.connect(voting).setStakingLimit(maxLimit, limitPerBlock);
 
-      const tx = await lido.connect(voting).removeStakingLimit();
-      const receipt = await tx.wait();
-
-      expect(receipt?.logs.length).to.equal(1);
-      await expect(tx).to.emit(lido, "StakingLimitRemoved");
+      await expect(lido.connect(voting).removeStakingLimit()).to.emit(lido, "StakingLimitRemoved");
 
       const info = await lido.getStakeLimitFullInfo();
       expect(info.isStakingLimitSet).to.be.false;

--- a/test/integration/core/staking-limits.integration.ts
+++ b/test/integration/core/staking-limits.integration.ts
@@ -1,0 +1,232 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { mine } from "@nomicfoundation/hardhat-network-helpers";
+
+import { ether } from "lib";
+import { getProtocolContext, ProtocolContext } from "lib/protocol";
+
+import { Snapshot } from "test/suite";
+
+import { Lido } from "../../../typechain-types";
+
+describe("Staking limits", () => {
+  let ctx: ProtocolContext;
+  let lido: Lido;
+  let snapshot: string;
+  let stranger: HardhatEthersSigner;
+  let voting: HardhatEthersSigner;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+    lido = ctx.contracts.lido;
+    [stranger] = await ethers.getSigners();
+    voting = await ctx.getSigner("voting");
+
+    snapshot = await Snapshot.take();
+  });
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  it("Should have expected staking limit info", async () => {
+    const info = await lido.getStakeLimitFullInfo();
+
+    expect(info.isStakingPaused_).to.be.false;
+    expect(info.isStakingLimitSet).to.be.true;
+    expect(info.currentStakeLimit).to.be.lte(ether("150000"));
+    expect(info.currentStakeLimit).to.be.gt(0);
+    expect(info.maxStakeLimit).to.equal(ether("150000"));
+    if (ctx.isScratch) {
+      expect(info.maxStakeLimitGrowthBlocks).to.equal(7500n);
+    } else {
+      expect(info.maxStakeLimitGrowthBlocks).to.equal(6400n);
+    }
+    expect(info.prevStakeLimit).to.be.lte(ether("150000"));
+  });
+
+  it("Should have staking not paused initially", async () => {
+    expect(await lido.isStakingPaused()).to.be.false;
+  });
+
+  it("Should not allow stranger to pause staking", async () => {
+    await expect(lido.connect(stranger).pauseStaking()).to.be.revertedWith("APP_AUTH_FAILED");
+
+    await lido.connect(voting).pauseStaking();
+    expect(await lido.isStakingPaused()).to.be.true;
+  });
+
+  it("Should prevent staking when paused", async () => {
+    await lido.connect(voting).pauseStaking();
+
+    await expect(lido.connect(stranger).submit(ethers.ZeroAddress, { value: ether("1") })).to.be.revertedWith(
+      "STAKING_PAUSED",
+    );
+  });
+
+  it("Should only allow authorized accounts to resume staking", async () => {
+    await lido.connect(voting).pauseStaking();
+
+    await expect(lido.connect(stranger).resumeStaking()).to.be.revertedWith("APP_AUTH_FAILED");
+
+    await lido.connect(voting).resumeStaking();
+    expect(await lido.isStakingPaused()).to.be.false;
+  });
+
+  it("Should allow staking after resumed", async () => {
+    await lido.connect(voting).pauseStaking();
+    await lido.connect(voting).resumeStaking();
+
+    await lido.connect(stranger).submit(ethers.ZeroAddress, { value: ether("1") });
+  });
+
+  it("Should only allow authorized accounts to set staking limit", async () => {
+    await expect(lido.connect(stranger).setStakingLimit(ether("1"), ether("0.01"))).to.be.revertedWith(
+      "APP_AUTH_FAILED",
+    );
+
+    await lido.connect(voting).setStakingLimit(ether("1"), ether("0.01"));
+  });
+
+  it("Should return correct staking limit after setting", async () => {
+    const limit = ether("1");
+
+    await lido.connect(voting).setStakingLimit(limit, ether("0.01"));
+    expect(await lido.getCurrentStakeLimit()).to.equal(limit);
+  });
+
+  it("Should not allow zero max stake limit", async () => {
+    await expect(lido.connect(voting).setStakingLimit(0, 0)).to.be.revertedWith("ZERO_MAX_STAKE_LIMIT");
+  });
+
+  it("Should not allow max stake limit above uint256", async () => {
+    const maxUint256 = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+    await expect(lido.connect(voting).setStakingLimit(maxUint256, maxUint256)).to.be.revertedWith(
+      "TOO_LARGE_MAX_STAKE_LIMIT",
+    );
+  });
+
+  it("Should prevent staking above limit", async () => {
+    await lido.connect(voting).setStakingLimit(ether("1"), ether("0.01"));
+
+    await expect(lido.connect(stranger).submit(ethers.ZeroAddress, { value: ether("10") })).to.be.revertedWith(
+      "STAKE_LIMIT",
+    );
+  });
+
+  it("Should only allow authorized accounts to remove staking limit", async () => {
+    await expect(lido.connect(stranger).removeStakingLimit()).to.be.revertedWith("APP_AUTH_FAILED");
+
+    await lido.connect(voting).removeStakingLimit();
+  });
+
+  it("Should allow staking above limit after removal", async () => {
+    await lido.connect(voting).setStakingLimit(ether("1"), ether("0.01"));
+    await lido.connect(voting).removeStakingLimit();
+
+    await lido.connect(stranger).submit(ethers.ZeroAddress, { value: ether("10") });
+  });
+
+  it("Should prevent staking when protocol is stopped", async () => {
+    await lido.connect(voting).stop();
+
+    await expect(lido.connect(stranger).submit(ethers.ZeroAddress, { value: ether("1") })).to.be.revertedWith(
+      "STAKING_PAUSED",
+    );
+
+    await lido.connect(voting).resume();
+  });
+
+  it("Should mint correct stETH amount when staking", async () => {
+    const stakeAmount = ether("1");
+
+    const balanceBefore = await lido.balanceOf(stranger.address);
+    await lido.connect(stranger).submit(ethers.ZeroAddress, { value: stakeAmount });
+    const balanceAfter = await lido.balanceOf(stranger.address);
+
+    expect(balanceAfter - balanceBefore).to.be.gte(stakeAmount - 2n);
+  });
+
+  const testCases = [
+    { maxLimit: 10n ** 6n, limitPerBlock: 10n ** 4n },
+    { maxLimit: 10n ** 12n, limitPerBlock: 10n ** 10n },
+    { maxLimit: 10n ** 18n, limitPerBlock: 10n ** 16n },
+  ];
+
+  for (const { maxLimit, limitPerBlock } of testCases) {
+    it(`Should update staking limits correctly with max=${maxLimit}, perBlock=${limitPerBlock}`, async () => {
+      const localSnapshot = await Snapshot.take();
+
+      // Set staking limit
+      await lido.connect(voting).setStakingLimit(maxLimit, limitPerBlock);
+
+      // Get initial stake limit
+      const stakingLimitBefore = await lido.getCurrentStakeLimit();
+      expect(stakingLimitBefore).to.equal(maxLimit);
+
+      // Submit stake
+      await lido.connect(stranger).submit(ethers.ZeroAddress, { value: limitPerBlock });
+
+      // Check limit decreased by submitted amount
+      const stakingLimitAfterSubmit = await lido.getCurrentStakeLimit();
+      expect(stakingLimitAfterSubmit).to.equal(stakingLimitBefore - limitPerBlock);
+
+      await mine(1);
+
+      // Check limit restored to max
+      const stakingLimitAfterBlock = await lido.getCurrentStakeLimit();
+      expect(stakingLimitAfterBlock).to.equal(stakingLimitBefore);
+
+      await Snapshot.restore(localSnapshot);
+    });
+  }
+
+  context("Staking limit events", () => {
+    it("Should emit correct event when setting staking limit", async () => {
+      const maxLimit = ether("1000");
+      const limitPerBlock = ether("100");
+
+      const tx = await lido.connect(voting).setStakingLimit(maxLimit, limitPerBlock);
+      const receipt = await tx.wait();
+
+      expect(receipt?.logs.length).to.equal(1);
+      await expect(tx).to.emit(lido, "StakingLimitSet").withArgs(maxLimit, limitPerBlock);
+
+      const info = await lido.getStakeLimitFullInfo();
+      expect(info.isStakingLimitSet).to.be.true;
+    });
+
+    it("Should emit correct event when changing staking limit", async () => {
+      const initialMax = ether("1000");
+      const initialPerBlock = ether("100");
+      await lido.connect(voting).setStakingLimit(initialMax, initialPerBlock);
+
+      const newMax = ether("2000");
+      const newPerBlock = ether("200");
+      const tx = await lido.connect(voting).setStakingLimit(newMax, newPerBlock);
+      const receipt = await tx.wait();
+
+      expect(receipt?.logs.length).to.equal(1);
+      await expect(tx).to.emit(lido, "StakingLimitSet").withArgs(newMax, newPerBlock);
+
+      const info = await lido.getStakeLimitFullInfo();
+      expect(info.isStakingLimitSet).to.be.true;
+    });
+
+    it("Should emit correct event when removing staking limit", async () => {
+      const maxLimit = ether("1000");
+      const limitPerBlock = ether("100");
+      await lido.connect(voting).setStakingLimit(maxLimit, limitPerBlock);
+
+      const tx = await lido.connect(voting).removeStakingLimit();
+      const receipt = await tx.wait();
+
+      expect(receipt?.logs.length).to.equal(1);
+      await expect(tx).to.emit(lido, "StakingLimitRemoved");
+
+      const info = await lido.getStakeLimitFullInfo();
+      expect(info.isStakingLimitSet).to.be.false;
+    });
+  });
+});

--- a/test/integration/core/staking-module.integration.ts
+++ b/test/integration/core/staking-module.integration.ts
@@ -1,0 +1,247 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+import { certainAddress, ether, impersonate } from "lib";
+import { LoadedContract } from "lib/contract";
+import { getProtocolContext, ProtocolContext } from "lib/protocol";
+import { randomPubkeys, randomSignatures } from "lib/protocol/helpers/nor";
+
+import { Snapshot } from "test/suite";
+
+describe("Integration: Staking module", () => {
+  let ctx: ProtocolContext;
+  let stranger: HardhatEthersSigner;
+
+  let snapshot: string;
+  let originalState: string;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+
+    snapshot = await Snapshot.take();
+
+    [stranger] = await ethers.getSigners();
+  });
+
+  beforeEach(async () => (originalState = await Snapshot.take()));
+
+  afterEach(async () => await Snapshot.restore(originalState));
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  async function testUpdateTargetValidatorsLimits(module: LoadedContract, addNodeOperatorSigner: HardhatEthersSigner) {
+    const votingSigner = await ctx.getSigner("voting");
+    const rewardAddress = certainAddress("rewardAddress");
+    const operatorName = "new_node_operator";
+
+    // Add node operator
+    const operatorId = await module.getFunction("getNodeOperatorsCount")();
+    await module.connect(addNodeOperatorSigner).getFunction("addNodeOperator")(operatorName, rewardAddress);
+
+    // Verify initial state
+    let summary = await module.getFunction("getNodeOperatorSummary")(operatorId);
+    expect(summary.targetLimitMode).to.equal(0);
+    expect(summary.targetValidatorsCount).to.equal(0);
+
+    // Should revert when called by unauthorized account
+    await expect(
+      module.connect(stranger).getFunction("updateTargetValidatorsLimits(uint256,uint256,uint256)")(operatorId, 1, 10),
+    ).to.be.revertedWith("APP_AUTH_FAILED");
+
+    // Grant STAKING_ROUTER_ROLE to stranger
+    await ctx.contracts.acl
+      .connect(votingSigner)
+      .grantPermission(
+        await stranger.getAddress(),
+        module.getAddress(),
+        ethers.keccak256(ethers.toUtf8Bytes("STAKING_ROUTER_ROLE")),
+      );
+
+    // Should revert with invalid operator id
+    await expect(
+      module.connect(stranger).getFunction("updateTargetValidatorsLimits(uint256,uint256,uint256)")(
+        operatorId + 1n,
+        1,
+        10,
+      ),
+    ).to.be.revertedWith("OUT_OF_RANGE");
+
+    // Set target mode 1
+    await module.connect(stranger).getFunction("updateTargetValidatorsLimits(uint256,uint256,uint256)")(
+      operatorId,
+      1,
+      10,
+    );
+    summary = await module.getFunction("getNodeOperatorSummary")(operatorId);
+    expect(summary.targetLimitMode).to.equal(1);
+    expect(summary.targetValidatorsCount).to.equal(10);
+
+    // Set target mode 2
+    await module.connect(stranger).getFunction("updateTargetValidatorsLimits(uint256,uint256,uint256)")(
+      operatorId,
+      2,
+      20,
+    );
+    summary = await module.getFunction("getNodeOperatorSummary")(operatorId);
+    expect(summary.targetLimitMode).to.equal(2);
+    expect(summary.targetValidatorsCount).to.equal(20);
+
+    // Set target mode 3 (force mode)
+    await module.connect(stranger).getFunction("updateTargetValidatorsLimits(uint256,uint256,uint256)")(
+      operatorId,
+      3,
+      30,
+    );
+    summary = await module.getFunction("getNodeOperatorSummary")(operatorId);
+    expect(summary.targetLimitMode).to.equal(3);
+    expect(summary.targetValidatorsCount).to.equal(30);
+
+    // Set target mode 0 (disabled)
+    await module.connect(stranger).getFunction("updateTargetValidatorsLimits(uint256,uint256,uint256)")(
+      operatorId,
+      0,
+      40,
+    );
+    summary = await module.getFunction("getNodeOperatorSummary")(operatorId);
+    expect(summary.targetLimitMode).to.equal(0);
+    expect(summary.targetValidatorsCount).to.equal(0); // Should always be 0 in disabled mode
+  }
+
+  async function testDecreaseVettedSigningKeysCount(
+    module: LoadedContract,
+    addNodeOperatorSigner: HardhatEthersSigner,
+  ) {
+    const votingSigner = await ctx.getSigner("voting");
+    const rewardAddress = certainAddress("rewardAddress");
+    const operatorName = "new_node_operator";
+
+    function prepareIdsCountsPayload(ids: bigint[], counts: bigint[]) {
+      return {
+        operatorIds: ethers.solidityPacked(Array(ids.length).fill("uint64"), ids),
+        keyCounts: ethers.solidityPacked(Array(counts.length).fill("uint128"), counts),
+      };
+    }
+
+    // Add node operator
+    const operatorId = await module.getFunction("getNodeOperatorsCount")();
+    await module.connect(addNodeOperatorSigner).getFunction("addNodeOperator")(operatorName, rewardAddress);
+
+    // Check operator reward address
+    const operatorInfo = await module.getFunction("getNodeOperator")(operatorId, true);
+    expect(operatorInfo.rewardAddress).to.equal(rewardAddress);
+
+    // Add signing keys
+    const keysCount = 10n;
+    await module.connect(await impersonate(rewardAddress, ether("1"))).getFunction("addSigningKeys")(
+      operatorId,
+      keysCount,
+      randomPubkeys(Number(keysCount)),
+      randomSignatures(Number(keysCount)),
+    );
+
+    // Set initial staking limit
+    await ctx.contracts.acl
+      .connect(votingSigner)
+      .grantPermission(
+        stranger.address,
+        module.getAddress(),
+        ethers.keccak256(ethers.toUtf8Bytes("SET_NODE_OPERATOR_LIMIT_ROLE")),
+      );
+
+    await module.connect(stranger).getFunction("setNodeOperatorStakingLimit")(operatorId, 8);
+
+    // Check initial state before unvetting
+    const operatorBefore = await module.getFunction("getNodeOperator")(operatorId, true);
+    expect(operatorBefore.totalAddedValidators).to.equal(keysCount);
+    expect(operatorBefore.totalVettedValidators).to.equal(8n);
+
+    // Prepare payload for decreasing vetted keys
+    const { operatorIds, keyCounts } = prepareIdsCountsPayload([operatorId], [6n]);
+
+    // Should revert when called by unauthorized account
+    await expect(
+      module.connect(stranger).getFunction("decreaseVettedSigningKeysCount")(operatorIds, keyCounts),
+    ).to.be.revertedWith("APP_AUTH_FAILED");
+
+    // Grant STAKING_ROUTER_ROLE to stranger
+    await ctx.contracts.acl
+      .connect(votingSigner)
+      .grantPermission(
+        stranger.address,
+        module.getAddress(),
+        ethers.keccak256(ethers.toUtf8Bytes("STAKING_ROUTER_ROLE")),
+      );
+
+    // Should revert with invalid operator id
+    const { operatorIds: invalidOperatorId } = prepareIdsCountsPayload([operatorId + 1n], [6n]);
+    await expect(
+      module.connect(stranger).getFunction("decreaseVettedSigningKeysCount")(invalidOperatorId, keyCounts),
+    ).to.be.revertedWith("OUT_OF_RANGE");
+
+    // Should revert when trying to increase vetted keys count
+    const { keyCounts: increasedKeyCounts } = prepareIdsCountsPayload([operatorId], [9n]);
+    await expect(
+      module.connect(stranger).getFunction("decreaseVettedSigningKeysCount")(operatorIds, increasedKeyCounts),
+    ).to.be.revertedWith("VETTED_KEYS_COUNT_INCREASED");
+
+    // Should revert when trying to set count higher than total
+    const { keyCounts: tooHighKeyCounts } = prepareIdsCountsPayload([operatorId], [11n]);
+    await expect(
+      module.connect(stranger).getFunction("decreaseVettedSigningKeysCount")(operatorIds, tooHighKeyCounts),
+    ).to.be.revertedWith("VETTED_KEYS_COUNT_INCREASED");
+
+    // Decrease vetted keys count
+    await module.connect(stranger).getFunction("decreaseVettedSigningKeysCount")(operatorIds, keyCounts);
+
+    // Check node operator state after partial unvetting
+    let nodeOperatorAfterPartialUnvetting = await module.getFunction("getNodeOperator")(operatorId, true);
+    expect(nodeOperatorAfterPartialUnvetting.totalAddedValidators).to.equal(keysCount);
+    expect(nodeOperatorAfterPartialUnvetting.totalVettedValidators).to.equal(6n);
+
+    // Second attempt with same count should not change anything
+    await module.connect(stranger).getFunction("decreaseVettedSigningKeysCount")(operatorIds, keyCounts);
+
+    nodeOperatorAfterPartialUnvetting = await module.getFunction("getNodeOperator")(operatorId, true);
+    expect(nodeOperatorAfterPartialUnvetting.totalAddedValidators).to.equal(keysCount);
+    expect(nodeOperatorAfterPartialUnvetting.totalVettedValidators).to.equal(6n);
+
+    // Decrease to zero
+    const { keyCounts: zeroKeyCounts } = prepareIdsCountsPayload([operatorId], [0n]);
+    await module.connect(stranger).getFunction("decreaseVettedSigningKeysCount")(operatorIds, zeroKeyCounts);
+
+    // Check node operator state after unvetting
+    const nodeOperatorAfterUnvetting = await module.getFunction("getNodeOperator")(operatorId, true);
+    expect(nodeOperatorAfterUnvetting.totalAddedValidators).to.equal(keysCount);
+    expect(nodeOperatorAfterUnvetting.totalVettedValidators).to.equal(0n);
+  }
+
+  it("should test NOR update target validators limits", async () => {
+    await testUpdateTargetValidatorsLimits(
+      ctx.contracts.nor as unknown as LoadedContract,
+      await ctx.getSigner("agent"),
+    );
+  });
+
+  it("should test NOR decrease vetted signing keys count", async () => {
+    await testDecreaseVettedSigningKeysCount(
+      ctx.contracts.nor as unknown as LoadedContract,
+      await ctx.getSigner("agent"),
+    );
+  });
+
+  it("should test SDVT update target validators limits", async () => {
+    await testUpdateTargetValidatorsLimits(
+      ctx.contracts.sdvt as unknown as LoadedContract,
+      await ctx.getSigner("easyTrack"),
+    );
+  });
+
+  it("should test SDVT decrease vetted signing keys count", async () => {
+    await testDecreaseVettedSigningKeysCount(
+      ctx.contracts.sdvt as unknown as LoadedContract,
+      await ctx.getSigner("easyTrack"),
+    );
+  });
+});

--- a/test/integration/core/withdrawal-edge-cases.integration.ts
+++ b/test/integration/core/withdrawal-edge-cases.integration.ts
@@ -1,0 +1,234 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { setBalance, time } from "@nomicfoundation/hardhat-network-helpers";
+
+import { Lido, WithdrawalQueueERC721 } from "typechain-types";
+
+import { ether, findEventsWithInterfaces } from "lib";
+import { getProtocolContext, ProtocolContext, report } from "lib/protocol";
+
+import { Snapshot } from "test/suite";
+
+describe("Integration: Withdrawal edge cases", () => {
+  let ctx: ProtocolContext;
+  let holder: HardhatEthersSigner;
+  let stranger: HardhatEthersSigner;
+  let lido: Lido;
+  let wq: WithdrawalQueueERC721;
+
+  let snapshot: string;
+  let originalState: string;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+    lido = ctx.contracts.lido;
+    wq = ctx.contracts.withdrawalQueue;
+
+    snapshot = await Snapshot.take();
+
+    [stranger, holder] = await ethers.getSigners();
+    await setBalance(holder.address, ether("1000000"));
+  });
+
+  beforeEach(async () => (originalState = await Snapshot.take()));
+
+  afterEach(async () => await Snapshot.restore(originalState));
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  async function finalizePendingRequests() {
+    // Finalize any pending requests first
+    while ((await wq.getLastRequestId()) !== (await wq.getLastFinalizedRequestId())) {
+      await report(ctx, { excludeVaultsBalances: true });
+      // Stake more ETH to increase buffer
+      await lido.connect(stranger).submit(ethers.ZeroAddress, { value: ether("10000") });
+    }
+  }
+
+  it("Should handle bunker mode with multiple batches", async () => {
+    await finalizePendingRequests();
+
+    const amount = ether("100");
+    const withdrawalAmount = ether("10");
+
+    expect(await lido.balanceOf(holder.address)).to.equal(0);
+
+    await lido.connect(holder).approve(wq.target, amount);
+    await lido.connect(holder).submit(ethers.ZeroAddress, { value: amount });
+
+    const stethInitialBalance = await lido.balanceOf(holder.address);
+
+    await report(ctx, { clDiff: ether("-1"), excludeVaultsBalances: true });
+
+    const stethFirstNegativeReportBalance = await lido.balanceOf(holder.address);
+
+    expect(stethInitialBalance).to.be.gt(stethFirstNegativeReportBalance);
+    expect(await wq.isBunkerModeActive()).to.be.true;
+
+    // First withdrawal request
+    const firstRequestTx = await wq.connect(holder).requestWithdrawals([withdrawalAmount], holder.address);
+    const firstRequestReceipt = await firstRequestTx.wait();
+    const [firstRequestEvent] = findEventsWithInterfaces(firstRequestReceipt!, "WithdrawalRequested", [wq.interface]);
+    const firstRequestId = firstRequestEvent!.args.requestId;
+
+    await report(ctx, { clDiff: ether("-0.1"), excludeVaultsBalances: true });
+
+    const stethSecondNegativeReportBalance = await lido.balanceOf(holder.address);
+
+    expect(stethFirstNegativeReportBalance).to.be.gt(stethSecondNegativeReportBalance);
+    expect(await wq.isBunkerModeActive()).to.be.true;
+
+    // Second withdrawal request
+    const secondRequestTx = await wq.connect(holder).requestWithdrawals([withdrawalAmount], holder.address);
+    const secondRequestReceipt = await secondRequestTx.wait();
+    const [secondRequestEvent] = findEventsWithInterfaces(secondRequestReceipt!, "WithdrawalRequested", [wq.interface]);
+    const secondRequestId = secondRequestEvent!.args.requestId;
+
+    const requestIds = [firstRequestId, secondRequestId];
+    const [firstStatus, secondStatus] = await wq.getWithdrawalStatus([...requestIds]);
+
+    // Amount of requested ETH should be equal, but shares are different
+    // because second request was affected by negative rebase twice
+    expect(firstStatus.amountOfStETH).to.equal(secondStatus.amountOfStETH);
+    expect(firstStatus.amountOfShares).to.be.lt(secondStatus.amountOfShares);
+
+    await report(ctx, { clDiff: ether("0.0001"), excludeVaultsBalances: true });
+
+    expect(await wq.isBunkerModeActive()).to.be.false;
+
+    const statuses = await wq.getWithdrawalStatus([...requestIds]);
+    statuses.forEach((status) => {
+      expect(status.isFinalized).to.be.true;
+    });
+
+    const lastCheckpointIndex = await wq.getLastCheckpointIndex();
+    const hints = await wq.findCheckpointHints([...requestIds], 1, lastCheckpointIndex);
+
+    const claimTx = await wq.connect(holder).claimWithdrawals([...requestIds], [...hints]);
+    const claimReceipt = await claimTx.wait();
+
+    // First claimed request should be less than requested amount because it caught negative rebase
+    const claimEvents = findEventsWithInterfaces(claimReceipt!, "WithdrawalClaimed", [wq.interface]);
+    expect(claimEvents![0].args.amountOfETH).to.be.lt(withdrawalAmount);
+    expect(claimEvents![1].args.amountOfETH).to.equal(withdrawalAmount);
+  });
+
+  it("should handle missed oracle report", async () => {
+    await finalizePendingRequests();
+
+    const amount = ether("100");
+
+    expect(await lido.balanceOf(holder.address)).to.equal(0);
+
+    // Submit initial stETH deposit
+    await lido.connect(holder).submit(ethers.ZeroAddress, { value: amount });
+
+    await report(ctx, { clDiff: ether("0.001"), excludeVaultsBalances: true });
+
+    // Create withdrawal request
+    await lido.connect(holder).approve(wq.target, amount);
+    const requestTx = await wq.connect(holder).requestWithdrawals([amount], holder.address);
+    const requestReceipt = await requestTx.wait();
+    const [requestEvent] = findEventsWithInterfaces(requestReceipt!, "WithdrawalRequested", [wq.interface]);
+    const requestId = requestEvent!.args.requestId;
+    const requestIds = [requestId];
+
+    // Skip next report by waiting extra time
+    const timeBeforeMissedReport = await time.latest();
+    await time.increase(24 * 60 * 60); // 24 hours
+    const timeAfterMissedReport = await time.latest();
+
+    // Check request not finalized after missed report
+    const [status] = await wq.getWithdrawalStatus([...requestIds]);
+    expect(timeBeforeMissedReport).to.be.lt(timeAfterMissedReport);
+    expect(status.isFinalized).to.be.false;
+
+    // Submit next report to finalize request
+    await report(ctx, { clDiff: ether("0.001"), excludeVaultsBalances: true });
+
+    // Verify request finalized
+    const [finalizedStatus] = await wq.getWithdrawalStatus([...requestIds]);
+    expect(finalizedStatus.isFinalized).to.be.true;
+
+    // Claim withdrawal
+    const lastCheckpointIndex = await wq.getLastCheckpointIndex();
+    const hints = await wq.findCheckpointHints([...requestIds], 1, lastCheckpointIndex);
+    const claimTx = await wq.connect(holder).claimWithdrawals([...requestIds], [...hints]);
+    const claimReceipt = await claimTx.wait();
+
+    // Verify claimed amount matches requested amount
+    const claimEvents = findEventsWithInterfaces(claimReceipt!, "WithdrawalClaimed", [wq.interface]);
+    expect(claimEvents![0].args.amountOfETH).to.equal(amount);
+  });
+
+  it("should handle several rebases correctly", async () => {
+    await finalizePendingRequests();
+
+    const amount = ether("100");
+    const withdrawalAmount = ether("10");
+
+    expect(await lido.balanceOf(holder.address)).to.equal(0);
+
+    await lido.connect(holder).approve(wq.target, amount);
+    await lido.connect(holder).submit(ethers.ZeroAddress, { value: amount });
+
+    const requestIds: bigint[] = [];
+
+    // First rebase - positive
+    await report(ctx, { clDiff: ether("0.001"), excludeVaultsBalances: true });
+
+    // Create first withdrawal request
+    const firstRequestTx = await wq.connect(holder).requestWithdrawals([withdrawalAmount], holder.address);
+    const firstRequestReceipt = await firstRequestTx.wait();
+    const [firstRequestEvent] = findEventsWithInterfaces(firstRequestReceipt!, "WithdrawalRequested", [wq.interface]);
+    requestIds.push(firstRequestEvent!.args.requestId);
+
+    // Second rebase - negative
+    await report(ctx, { clDiff: ether("-0.1"), excludeVaultsBalances: true });
+    expect(await wq.isBunkerModeActive()).to.be.true;
+
+    // Verify first request finalized
+    const [firstStatus] = await wq.getWithdrawalStatus([requestIds[0]]);
+    expect(firstStatus.isFinalized).to.be.true;
+
+    // Create second withdrawal request
+    const secondRequestTx = await wq.connect(holder).requestWithdrawals([withdrawalAmount], holder.address);
+    const secondRequestReceipt = await secondRequestTx.wait();
+    const [secondRequestEvent] = findEventsWithInterfaces(secondRequestReceipt!, "WithdrawalRequested", [wq.interface]);
+    requestIds.push(secondRequestEvent!.args.requestId);
+
+    // Third rebase - negative
+    await report(ctx, { clDiff: ether("-0.1"), excludeVaultsBalances: true });
+    expect(await wq.isBunkerModeActive()).to.be.true;
+
+    // Create third withdrawal request
+    const thirdRequestTx = await wq.connect(holder).requestWithdrawals([withdrawalAmount], holder.address);
+    const thirdRequestReceipt = await thirdRequestTx.wait();
+    const [thirdRequestEvent] = findEventsWithInterfaces(thirdRequestReceipt!, "WithdrawalRequested", [wq.interface]);
+    requestIds.push(thirdRequestEvent!.args.requestId);
+
+    // Fourth rebase - positive
+    await report(ctx, { clDiff: ether("0.0000001"), excludeVaultsBalances: true });
+    expect(await wq.isBunkerModeActive()).to.be.false;
+
+    // Verify all requests finalized
+    const statuses = await wq.getWithdrawalStatus(requestIds);
+    for (const status of statuses) {
+      expect(status.isFinalized).to.be.true;
+    }
+
+    // Claim withdrawals
+    const lastCheckpointIndex = await wq.getLastCheckpointIndex();
+    const hints = await wq.findCheckpointHints([...requestIds], 1, lastCheckpointIndex);
+    const claimTx = await wq.connect(holder).claimWithdrawals([...requestIds], [...hints]);
+    const claimReceipt = await claimTx.wait();
+
+    // Verify claimed amounts
+    const claimEvents = findEventsWithInterfaces(claimReceipt!, "WithdrawalClaimed", [wq.interface]);
+    expect(claimEvents![0].args.amountOfETH).to.be.lt(withdrawalAmount);
+    expect(claimEvents![1].args.amountOfETH).to.be.lt(withdrawalAmount);
+    expect(claimEvents![2].args.amountOfETH).to.equal(withdrawalAmount);
+  });
+});

--- a/test/integration/core/withdrawal-happy-path.integration.ts
+++ b/test/integration/core/withdrawal-happy-path.integration.ts
@@ -1,0 +1,193 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { setBalance } from "@nomicfoundation/hardhat-network-helpers";
+
+import { ether, findEvents, findEventsWithInterfaces } from "lib";
+import { getProtocolContext, ProtocolContext, report } from "lib/protocol";
+
+import { Snapshot } from "test/suite";
+
+describe("Integration: Withdrawal happy path", () => {
+  let ctx: ProtocolContext;
+  let holder: HardhatEthersSigner;
+
+  let snapshot: string;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+
+    snapshot = await Snapshot.take();
+
+    [holder] = await ethers.getSigners();
+    await setBalance(holder.address, ether("1000000"));
+  });
+
+  after(async () => await Snapshot.restore(snapshot));
+
+  it("Should successfully request and claim withdrawals", async () => {
+    const REQUESTS_COUNT = 10n;
+    const REQUEST_AMOUNT = ether("1");
+    const REQUESTS_SUM = REQUEST_AMOUNT * REQUESTS_COUNT;
+
+    const { withdrawalQueue: wq, lido } = ctx.contracts;
+
+    // Finalize any pending requests first
+    while ((await wq.getLastRequestId()) !== (await wq.getLastFinalizedRequestId())) {
+      await report(ctx, { clDiff: ether("1") });
+      // Submit more ETH to increase buffer
+      await lido.submit(ethers.ZeroAddress, { value: ether("10000") });
+    }
+
+    // Get initial stETH holder balance
+    await lido.connect(holder).submit(ethers.ZeroAddress, { value: ether("10000") });
+    expect(await lido.balanceOf(holder.address)).to.be.gte(REQUESTS_SUM);
+
+    // Get initial state
+    const uncountedStethShares = await lido.sharesOf(wq.target);
+    const noRequests = await wq.getWithdrawalRequests(holder.address);
+    expect(noRequests.length).to.equal(0);
+
+    const lastRequestId = await wq.getLastRequestId();
+    const lastFinalizedRequestId = await wq.getLastFinalizedRequestId();
+    const lastCheckpointIndexBefore = await wq.getLastCheckpointIndex();
+    const unfinalizedSteth = await wq.unfinalizedStETH();
+
+    const preReportRequestShares = await lido.getSharesByPooledEth(REQUEST_AMOUNT);
+
+    // Make withdrawal requests
+    const stethBalanceBefore = await lido.balanceOf(holder.address);
+    await lido.approve(wq.target, REQUESTS_SUM);
+    const requests = Array(parseInt(REQUESTS_COUNT.toString())).fill(REQUEST_AMOUNT);
+    const requestTx = await wq.connect(holder).requestWithdrawals(requests, holder.address);
+    const stethBalanceAfter = await lido.balanceOf(holder.address);
+
+    // Verify request state
+    expect(stethBalanceBefore - stethBalanceAfter).to.be.closeTo(REQUESTS_SUM, 2n * REQUESTS_COUNT);
+
+    const sharesToBurn = (await lido.sharesOf(wq.target)) - uncountedStethShares;
+
+    const requestReceipt = await requestTx.wait();
+    const withdrawalRequestedEvents = findEventsWithInterfaces(requestReceipt!, "WithdrawalRequested", [wq.interface]);
+    expect(withdrawalRequestedEvents?.length).to.equal(REQUESTS_COUNT);
+    withdrawalRequestedEvents?.forEach((event, i) => {
+      expect(event?.args.requestId).to.equal(BigInt(i) + lastRequestId + 1n);
+      expect(event?.args.amountOfStETH).to.be.closeTo(REQUEST_AMOUNT, 1n);
+      expect(event?.args.amountOfShares).to.be.closeTo(preReportRequestShares, 1n);
+      expect(event?.args.requestor).to.equal(holder.address);
+      expect(event?.args.owner).to.equal(holder.address);
+    });
+
+    // Verify NFT transfers (token transfers logs have the same signature as NFT transfers so
+    // filtering them also by number of indexed params)
+    const transferEvents = findEventsWithInterfaces(requestReceipt!, "Transfer", [wq.interface], 3);
+    expect(transferEvents?.length).to.equal(REQUESTS_COUNT);
+    transferEvents?.forEach((event, i) => {
+      expect(event?.args.tokenId).to.equal(BigInt(i) + lastRequestId + 1n);
+      expect(event?.args.from).to.equal(ethers.ZeroAddress);
+      expect(event?.args.to).to.equal(holder.address);
+    });
+
+    // Check request statuses
+    const requestIds = await wq.getWithdrawalRequests(holder.address);
+    const statuses = await wq.getWithdrawalStatus([...requestIds]);
+    const claimableEther = await wq.getClaimableEther([...requestIds], Array(requestIds.length).fill(0));
+    expect(requestIds.length).to.equal(REQUESTS_COUNT);
+    expect(statuses.length).to.equal(REQUESTS_COUNT);
+    requestIds.forEach((requestId, i) => {
+      expect(requestId).to.equal(BigInt(i) + lastRequestId + 1n);
+      const [amountOfStETH, amountOfShares, owner, , isFinalized, isClaimed] = statuses[i];
+      expect(amountOfStETH).to.be.closeTo(REQUEST_AMOUNT, 1n);
+      expect(amountOfShares).to.be.closeTo(preReportRequestShares, 1n);
+      expect(owner).to.equal(holder.address);
+      expect(isFinalized).to.be.false;
+      expect(isClaimed).to.be.false;
+      expect(claimableEther[i]).to.equal(0);
+    });
+
+    // First oracle report
+    let reportTx = (await report(ctx, { clDiff: ether("0.00000000000001") })).reportTx;
+    const reportReceipt = await reportTx!.wait();
+
+    // second report requests will get finalized for sure
+    if (findEvents(reportReceipt!, "WithdrawalsFinalized").length !== 1) {
+      reportTx = (await report(ctx, { clDiff: ether("0.00000000000001") })).reportTx;
+    }
+
+    const [parsedFinalizedEvent] = findEventsWithInterfaces(reportReceipt!, "WithdrawalsFinalized", [wq.interface]);
+    expect(parsedFinalizedEvent?.args.from).to.equal(lastFinalizedRequestId + 1n);
+    expect(parsedFinalizedEvent?.args.to).to.equal(REQUESTS_COUNT + lastRequestId);
+    expect(parsedFinalizedEvent?.args.amountOfETHLocked).to.be.closeTo(REQUESTS_SUM + unfinalizedSteth, 1n);
+    expect(parsedFinalizedEvent?.args.sharesToBurn).to.be.closeTo(sharesToBurn, 1n);
+
+    // Verify post-finalization state
+    expect(await wq.getLastFinalizedRequestId()).to.equal(requestIds[requestIds.length - 1]);
+    const lastCheckpointIndex = await wq.getLastCheckpointIndex();
+    expect(lastCheckpointIndex).to.equal(lastCheckpointIndexBefore + 1n);
+
+    // Verify post-report state
+    const postReportStatuses = await wq.getWithdrawalStatus([...requestIds]);
+    const postReportClaimableEther = await wq.getClaimableEther(
+      [...requestIds],
+      Array(requestIds.length).fill(lastCheckpointIndex),
+    );
+
+    requestIds.forEach((requestId, i) => {
+      expect(requestId).to.equal(BigInt(i) + lastRequestId + 1n);
+      const [amountOfStETH, amountOfShares, owner, , isFinalized, isClaimed] = postReportStatuses[i];
+      expect(amountOfStETH).to.equal(statuses[i][0]); // amountOfStETH remains unchanged
+      expect(amountOfShares).to.equal(statuses[i][1]); // amountOfShares remains unchanged
+      expect(owner).to.equal(holder.address);
+      expect(isFinalized).to.be.true;
+      expect(isClaimed).to.be.false;
+      expect(postReportClaimableEther[i]).to.be.closeTo(REQUEST_AMOUNT, 1n);
+    });
+
+    // Claim withdrawals
+    const hints = await wq.findCheckpointHints([...requestIds], 1, lastCheckpointIndex);
+    const balanceBefore = await ethers.provider.getBalance(holder.address);
+
+    const claimTx = await wq.connect(holder).claimWithdrawals([...requestIds], [...hints]);
+    const receipt = await claimTx.wait();
+    const balanceAfter = await ethers.provider.getBalance(holder.address);
+
+    // Verify claim results
+    const gasCost = receipt!.gasUsed * receipt!.gasPrice;
+    expect(balanceAfter - balanceBefore + gasCost).to.be.closeTo(REQUESTS_SUM, 1n * REQUESTS_COUNT);
+
+    const claimEvents = findEventsWithInterfaces(receipt!, "WithdrawalClaimed", [wq.interface]);
+    expect(claimEvents?.length).to.equal(REQUESTS_COUNT);
+
+    claimEvents?.forEach((event, i) => {
+      expect(event?.args.requestId).to.equal(BigInt(i) + lastRequestId + 1n);
+      expect(event?.args.receiver).to.equal(holder.address);
+      expect(event?.args.owner).to.equal(holder.address);
+      expect(event?.args.amountOfETH).to.be.closeTo(REQUEST_AMOUNT, 1n);
+    });
+
+    // Verify NFT transfers
+    const claimTransferEvents = findEventsWithInterfaces(receipt!, "Transfer", [wq.interface], 3);
+    expect(claimTransferEvents?.length).to.equal(REQUESTS_COUNT);
+    claimTransferEvents?.forEach((event, i) => {
+      expect(event?.args.tokenId).to.equal(BigInt(i) + lastRequestId + 1n);
+      expect(event?.args.to).to.equal(ethers.ZeroAddress);
+      expect(event?.args.from).to.equal(holder.address);
+    });
+
+    // Verify final state
+    const postClaimStatuses = await wq.getWithdrawalStatus([...requestIds]);
+    const postClaimClaimableEther = await wq.getClaimableEther([...requestIds], [...hints]);
+
+    requestIds.forEach((requestId, i) => {
+      expect(requestId).to.equal(BigInt(i) + lastRequestId + 1n);
+      const [amountOfStETH, amountOfShares, owner, , isFinalized, isClaimed] = postClaimStatuses[i];
+      expect(amountOfStETH).to.equal(statuses[i][0]);
+      expect(amountOfShares).to.equal(statuses[i][1]);
+      expect(owner).to.equal(holder.address);
+      expect(isFinalized).to.be.true;
+      expect(isClaimed).to.be.true;
+      expect(postClaimClaimableEther[i]).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
Migrated same-named tests from https://github.com/lidofinance/scripts/:
staking-limits.integration.ts
hash-consensus.integration.ts
staking-module.integration.ts
dsm-keys-unvetting.integration.t
withdrawal-edge-cases.integration.ts
dsm-pause-deposits.integration.ts
node-operators-flow.integration.ts
withdrawal-happy-path.integration.ts
el-rewards.integration.ts

NB: the tests have been adopted for the https://github.com/lidofinance/core/pull/978 as well