### PR TITLE
ci: pin coverage action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn test:coverage
 
       - name: Produce the coverage report
-        uses: lidofinance/coverage-action@4ee65a3ad48fa3246ac32da9cf6b702b001599f8
+        uses: lidofinance/coverage-action@a94351baa279790f736655b1891178b1515594ea
         with:
           path: ./coverage/cobertura-coverage.xml
           publish: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn test:coverage
 
       - name: Produce the coverage report
-        uses: insightsengineering/coverage-action@v2
+        uses: lidofinance/coverage-action@4ee65a3ad48fa3246ac32da9cf6b702b001599f8
         with:
           path: ./coverage/cobertura-coverage.xml
           publish: true


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/coverage.yml` file to update the coverage action used for producing the coverage report.

* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6L32-R32): Updated the `uses` line to reference the `lidofinance/coverage-action` with a specific commit hash instead of `insightsengineering/coverage-action@v2`.