### PR TITLE
feat: infinite stacktraces

### DIFF
--- a/test/hooks/index.ts
+++ b/test/hooks/index.ts
@@ -2,6 +2,9 @@ import * as Mocha from "mocha";
 
 import "./assertion/revertedWithOZAccessControlError";
 
+// Increase number of stack frames shown in error messages
+Error.stackTraceLimit = Infinity;
+
 /**
  * This is used to add custom assertions to the Chai assertion library in the test suite when it's run in parallel mode.
  */


### PR DESCRIPTION
Removes the limit of 10 frames per stack trace. Very helpful for tests. Shout out to @loga4!