### PR TITLE
Disallow empty codehash for vaults

### DIFF
--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -76,7 +76,7 @@ contract VaultHub is PausableUntilWithRoles {
         0xb158a1a9015c52036ff69e7937a7bb424e82a8c4cbec5c5309994af06d825300;
 
     /// @notice codehash of the account with no code
-    bytes32 private constant EMPTY_CODEHASH = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
+    bytes32 private constant EMPTY_CODEHASH = keccak256("");
 
     /// @notice role that allows to connect vaults to the hub
     bytes32 public constant VAULT_MASTER_ROLE = keccak256("Vaults.VaultHub.VaultMasterRole");

--- a/scripts/scratch/steps/0145-deploy-vaults.ts
+++ b/scripts/scratch/steps/0145-deploy-vaults.ts
@@ -33,12 +33,13 @@ export async function main() {
   ]);
   const dashboardAddress = await dashboard.getAddress();
 
-  // Deploy Dashboard implementation contract
   const beacon = await deployWithoutProxy(Sk.stakingVaultBeacon, "UpgradeableBeacon", deployer, [impAddress, deployer]);
   const beaconAddress = await beacon.getAddress();
 
   // Deploy BeaconProxy to get bytecode and add it to whitelist
   const vaultBeaconProxy = await ethers.deployContract("PinnedBeaconProxy", [beaconAddress, "0x"]);
+  await vaultBeaconProxy.waitForDeployment();
+
   const vaultBeaconProxyCode = await ethers.provider.getCode(await vaultBeaconProxy.getAddress());
   const vaultBeaconProxyCodeHash = keccak256(vaultBeaconProxyCode);
 


### PR DESCRIPTION
EXTCODEHASH returns keccak(0x) if account exists but has no code sometimes, so we revert on adding it.