### PR TITLE
feat: update deploy params for pectra

### DIFF
--- a/scripts/scratch/deployed-testnet-defaults.json
+++ b/scripts/scratch/deployed-testnet-defaults.json
@@ -78,7 +78,7 @@
   },
   "accountingOracle": {
     "deployParameters": {
-      "consensusVersion": 2
+      "consensusVersion": 3
     }
   },
   "hashConsensusForValidatorsExitBusOracle": {
@@ -89,7 +89,7 @@
   },
   "validatorsExitBusOracle": {
     "deployParameters": {
-      "consensusVersion": 2
+      "consensusVersion": 3
     }
   },
   "depositSecurityModule": {


### PR DESCRIPTION
This pull request updates the `consensusVersion` parameter in the `deployed-testnet-defaults.json` file to ensure compatibility with the latest version of the oracle algorithm.

Configuration updates:

* `consensusVersion` for `accountingOracle` from `2` to `3`.
* `consensusVersion` for `validatorsExitBusOracle` from `2` to `3`.