### PR TITLE
fix: exclude exitType & renaming

### DIFF
--- a/contracts/0.8.9/interfaces/IValidatorsExitBus.sol
+++ b/contracts/0.8.9/interfaces/IValidatorsExitBus.sol
@@ -10,7 +10,7 @@ interface IValidatorsExitBus {
 
     struct DeliveryHistory {
         // index in array of requests
-        uint256 lastDeliveredKeyIndex;
+        uint256 lastDeliveredExitDataIndex;
         uint256 timestamp;
     }
 
@@ -19,10 +19,9 @@ interface IValidatorsExitBus {
     function submitExitRequestsData(ExitRequestData calldata request) external;
 
     function triggerExits(
-        ExitRequestData calldata request,
-        uint256[] calldata keyIndexes,
-        address refundRecipient,
-        uint8 exitType
+        ExitRequestData calldata exitsData,
+        uint256[] calldata exitDataIndexes,
+        address refundRecipient
     ) external payable;
 
     function setExitRequestLimit(uint256 maxExitRequests, uint256 exitsPerFrame, uint256 frameDuration) external;

--- a/test/0.8.9/contracts/ValidatorsExitBus__Harness.sol
+++ b/test/0.8.9/contracts/ValidatorsExitBus__Harness.sol
@@ -47,14 +47,14 @@ contract ValidatorsExitBus__Harness is ValidatorsExitBusOracle, ITimeProvider {
         uint256 totalItemsCount,
         uint256 deliveredItemsCount,
         uint256 contractVersion,
-        uint256 lastDeliveredKeyIndex
+        uint256 lastDeliveredExitDataIndex
     ) external {
         _storeExitRequestHash(
             exitRequestHash,
             totalItemsCount,
             deliveredItemsCount,
             contractVersion,
-            DeliveryHistory(lastDeliveredKeyIndex, block.timestamp)
+            DeliveryHistory(lastDeliveredExitDataIndex, block.timestamp)
         );
     }
 }

--- a/test/0.8.9/oracle/validator-exit-bus-oracle.triggerExits.test.ts
+++ b/test/0.8.9/oracle/validator-exit-bus-oracle.triggerExits.test.ts
@@ -166,7 +166,6 @@ describe("ValidatorsExitBusOracle.sol:triggerExits", () => {
       { data: reportFields.data, dataFormat: reportFields.dataFormat },
       [0, 1, 2, 3],
       ZERO_ADDRESS,
-      0,
       { value: 4 },
     );
 
@@ -174,7 +173,7 @@ describe("ValidatorsExitBusOracle.sol:triggerExits", () => {
 
     await expect(tx)
       .to.emit(triggerableWithdrawalsGateway, "Mock__triggerFullWithdrawalsTriggered")
-      .withArgs(requests.length, admin.address, 0);
+      .withArgs(requests.length, admin.address, 1);
   });
 
   it("should triggers exits only for validators in selected request indexes", async () => {
@@ -182,7 +181,6 @@ describe("ValidatorsExitBusOracle.sol:triggerExits", () => {
       { data: reportFields.data, dataFormat: reportFields.dataFormat },
       [0, 1, 3],
       ZERO_ADDRESS,
-      0,
       {
         value: 10,
       },
@@ -192,7 +190,7 @@ describe("ValidatorsExitBusOracle.sol:triggerExits", () => {
 
     await expect(tx)
       .to.emit(triggerableWithdrawalsGateway, "Mock__triggerFullWithdrawalsTriggered")
-      .withArgs(requests.length, admin.address, 0);
+      .withArgs(requests.length, admin.address, 1);
   });
 
   it("should revert with error if the hash of `requestsData` was not previously submitted in the VEB", async () => {
@@ -204,7 +202,6 @@ describe("ValidatorsExitBusOracle.sol:triggerExits", () => {
         },
         [0],
         ZERO_ADDRESS,
-        0,
         { value: 2 },
       ),
     ).to.be.revertedWithCustomError(oracle, "ExitHashNotSubmitted");
@@ -212,39 +209,27 @@ describe("ValidatorsExitBusOracle.sol:triggerExits", () => {
 
   it("should revert with error if requested index out of range", async () => {
     await expect(
-      oracle.triggerExits({ data: reportFields.data, dataFormat: reportFields.dataFormat }, [5], ZERO_ADDRESS, 0, {
+      oracle.triggerExits({ data: reportFields.data, dataFormat: reportFields.dataFormat }, [5], ZERO_ADDRESS, {
         value: 2,
       }),
     )
-      .to.be.revertedWithCustomError(oracle, "KeyIndexOutOfRange")
+      .to.be.revertedWithCustomError(oracle, "ExitDataIndexOutOfRange")
       .withArgs(5, 4);
   });
 
   it("should revert with an error if the key index array contains duplicates", async () => {
     await expect(
-      oracle.triggerExits(
-        { data: reportFields.data, dataFormat: reportFields.dataFormat },
-        [1, 2, 2],
-        ZERO_ADDRESS,
-        0,
-        {
-          value: 2,
-        },
-      ),
-    ).to.be.revertedWithCustomError(oracle, "InvalidKeyIndexSortOrder");
+      oracle.triggerExits({ data: reportFields.data, dataFormat: reportFields.dataFormat }, [1, 2, 2], ZERO_ADDRESS, {
+        value: 2,
+      }),
+    ).to.be.revertedWithCustomError(oracle, "InvalidExitDataIndexSortOrder");
   });
 
   it("should revert with an error if the key index array is not strictly increasing", async () => {
     await expect(
-      oracle.triggerExits(
-        { data: reportFields.data, dataFormat: reportFields.dataFormat },
-        [1, 2, 2],
-        ZERO_ADDRESS,
-        0,
-        {
-          value: 2,
-        },
-      ),
-    ).to.be.revertedWithCustomError(oracle, "InvalidKeyIndexSortOrder");
+      oracle.triggerExits({ data: reportFields.data, dataFormat: reportFields.dataFormat }, [1, 2, 2], ZERO_ADDRESS, {
+        value: 2,
+      }),
+    ).to.be.revertedWithCustomError(oracle, "InvalidExitDataIndexSortOrder");
   });
 });

--- a/test/0.8.9/oracle/validator-exit-bus.helpers.test.ts
+++ b/test/0.8.9/oracle/validator-exit-bus.helpers.test.ts
@@ -107,14 +107,14 @@ describe("ValidatorsExitBusOracle.sol:helpers", () => {
       );
     });
 
-    it("reverts if the index is out of range (KeyIndexOutOfRange)", async () => {
+    it("reverts if the index is out of range (ExitDataIndexOutOfRange)", async () => {
       // We have only 1 request => 64 bytes
       const exitRequests = [{ moduleId: 1, nodeOpId: 1, valIndex: 1, valPubkey: PUBKEYS[0] }];
       const data = encodeExitRequestsDataList(exitRequests);
 
       // There is exactly 1 request, so index=1 is out of range (should be 0)
       await expect(oracle.unpackExitRequest(data, DATA_FORMAT_LIST, 1))
-        .to.be.revertedWithCustomError(oracle, "KeyIndexOutOfRange")
+        .to.be.revertedWithCustomError(oracle, "ExitDataIndexOutOfRange")
         .withArgs(1, 1); // index=1, total=1
     });
   });
@@ -142,7 +142,7 @@ describe("ValidatorsExitBusOracle.sol:helpers", () => {
       const totalItemsCount = 5;
       const deliveredItemsCount = 2;
       const contractVersion = 42;
-      const lastDeliveredKeyIndex = 1;
+      const lastDeliveredExitDataIndex = 1;
 
       // Call the helper to store the hash
       await oracle.storeExitRequestHash(
@@ -150,7 +150,7 @@ describe("ValidatorsExitBusOracle.sol:helpers", () => {
         totalItemsCount,
         deliveredItemsCount,
         contractVersion,
-        lastDeliveredKeyIndex,
+        lastDeliveredExitDataIndex,
       );
 
       const [returnedTotalItemsCount, returnedDeliveredItemsCount, returnedHistory] =
@@ -160,7 +160,7 @@ describe("ValidatorsExitBusOracle.sol:helpers", () => {
       expect(returnedDeliveredItemsCount).to.equal(deliveredItemsCount);
       expect(returnedHistory.length).to.equal(1);
       const [firstDelivery] = returnedHistory;
-      expect(firstDelivery.lastDeliveredKeyIndex).to.equal(lastDeliveredKeyIndex);
+      expect(firstDelivery.lastDeliveredExitDataIndex).to.equal(lastDeliveredExitDataIndex);
     });
   });
 });


### PR DESCRIPTION
Refactors for naming consistency with documentation and removes exitType from triggerExits (now fixed to 1 internally):
    - keyIndex → exitDataIndex in triggerExits
    - lastDeliveredKeyIndex → lastDeliveredExitDataIndex in DeliveryHistory

Renamed related errors:
    KeyWasNotDelivered → ExitDataWasNotDelivered
    KeyIndexOutOfRange → ExitDataIndexOutOfRange
    InvalidKeyIndexSortOrder → InvalidExitDataIndexSortOrder
    
  Changed triggerExits signature:  
  
    function triggerExits(
          ExitRequestData calldata exitsData,
          uint256[] calldata exitDataIndexes,
          address refundRecipient
      ) external payable;
  
