### PR TITLE
Fix typos in 0.8.25 contracts

### DIFF
--- a/contracts/0.8.25/vaults/StakingVault.sol
+++ b/contracts/0.8.25/vaults/StakingVault.sol
@@ -346,7 +346,7 @@ contract StakingVault is IStakingVault, Ownable2StepUpgradeable {
      * @param _amounts Amounts of ether to withdraw. If array is empty or amount value is zero, triggers full withdrawals.
      * @param _excessRefundRecipient Address to receive any excess withdrawal fee
      * @dev    The caller must provide sufficient fee via msg.value to cover the withdrawal request costs
-     * @dev    You can use `calculateValidatorWithdrawalFee` to calculate the fee but it's actual only for the block
+     * @dev    You can use `calculateValidatorWithdrawalFee` to calculate the fee but it's accurate only for the block
      *         it's called. The fee may change from block to block, so it's recommended to send fee with some surplus.
      *         The excess amount will be refunded.
      */

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -471,7 +471,7 @@ contract VaultHub is PausableUntilWithRoles {
     }
 
     /// @notice transfer the ownership of the vault to a new owner
-    /// without disconnection it from the hub
+    /// without disconnecting it from the hub
     /// @param _vault vault address
     /// @param _newOwner new owner address
     /// @dev msg.sender should be vault's owner

--- a/contracts/0.8.25/vaults/dashboard/Dashboard.sol
+++ b/contracts/0.8.25/vaults/dashboard/Dashboard.sol
@@ -99,7 +99,7 @@ contract Dashboard is NodeOperatorFee {
     // ==================== View Functions ====================
 
     /**
-     * @notice Returns the vault socket data for the staking vault.
+     * @notice Returns the vault connection data for the staking vault.
      * @return VaultConnection struct containing vault data
      */
     function vaultConnection() public view returns (VaultHub.VaultConnection memory) {
@@ -114,7 +114,7 @@ contract Dashboard is NodeOperatorFee {
     }
 
     /**
-     * @notice Returns the number of stETHshares minted
+     * @notice Returns the number of stETH shares minted
      */
     function liabilityShares() public view returns (uint256) {
         return VAULT_HUB.liabilityShares(address(_stakingVault()));

--- a/contracts/0.8.25/vaults/dashboard/Permissions.sol
+++ b/contracts/0.8.25/vaults/dashboard/Permissions.sol
@@ -89,7 +89,7 @@ abstract contract Permissions is AccessControlConfirmable {
     bytes32 public constant PDG_PROVE_VALIDATOR_ROLE = keccak256("vaults.Permissions.PDGProveValidator");
 
     /**
-     * @notice Permission for unguarnateed deposit to trusted validators
+     * @notice Permission for unguaranteed deposit to trusted validators
      */
     bytes32 public constant UNGUARANTEED_BEACON_CHAIN_DEPOSIT_ROLE =
         keccak256("vaults.Permissions.UnguaranteedBeaconChainDeposit");

--- a/contracts/0.8.25/vaults/predeposit_guarantee/CLProofVerifier.sol
+++ b/contracts/0.8.25/vaults/predeposit_guarantee/CLProofVerifier.sol
@@ -16,7 +16,7 @@ import {IPredepositGuarantee} from "../interfaces/IPredepositGuarantee.sol";
  *
  * CLProofVerifier is base abstract contract that provides internal method to verify
  * merkle proofs of validator entry in CL. It uses concatenated proofs that prove
- * validator existence in CL just from pubkey and withdrawalCredentials againts Beacon block root
+ * validator existence in CL just from pubkey and withdrawalCredentials against Beacon block root
  * stored in BeaconRoots system contract (see EIP-4788).
  *
  */

--- a/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol
+++ b/contracts/0.8.25/vaults/predeposit_guarantee/PredepositGuarantee.sol
@@ -22,7 +22,7 @@ import {IPredepositGuarantee} from "../interfaces/IPredepositGuarantee.sol";
  *         While only Staking Vault ether is used to deposit to the beacon chain, NO's ether is locked.
  *         And can only be unlocked if the validator is proven to have valid Withdrawal Credentials on Ethereum Consensus Layer.
  *         Merkle proofs against Beacon Block Root are used to prove either validator's validity or invalidity
- *         where invalid validators's ether can be compensated back to the staking vault owner.
+ *         where invalid validators' ether can be compensated back to the staking vault owner.
  *         A system of NO's guarantors can be used to allow NOs to handle deposits and verifications
  *         while guarantors provide ether.
  *
@@ -45,8 +45,8 @@ contract PredepositGuarantee is IPredepositGuarantee, CLProofVerifier, PausableU
      * @param NONE - initial stage
      * @param PREDEPOSITED - PREDEPOSIT_AMOUNT is deposited with this validator by the vault
      * @param PROVEN - validator is proven to be valid and can be used to deposit to beacon chain
-     * @param DISPROVEN - validator is proven to have wrong WC and it's PREDEPOSIT_AMOUNT can be compensated to staking vault owner
-     * @param COMPENSATED - disproven validator has it's PREDEPOSIT_AMOUNT ether compensated to staking vault owner and validator cannot be used in PDG anymore
+     * @param DISPROVEN - validator is proven to have wrong WC and its PREDEPOSIT_AMOUNT can be compensated to staking vault owner
+     * @param COMPENSATED - disproven validator has its PREDEPOSIT_AMOUNT ether compensated to staking vault owner and validator cannot be used in PDG anymore
      */
     enum ValidatorStage {
         NONE,


### PR DESCRIPTION
## Summary
- fix minor typos in VaultHub, Dashboard and Permissions docs
- correct wording in StakingVault comments
- fix spelling errors in PredepositGuarantee and CLProofVerifier

## Testing
- `yarn test` *(fails: unable to download yarn)*
- `forge test` *(fails: command not found)*