### PR TITLE
fix(NodeOperatorFee): revert NO fee change if vault is in quarantine

### DIFF
--- a/contracts/0.8.25/vaults/LazyOracle.sol
+++ b/contracts/0.8.25/vaults/LazyOracle.sol
@@ -77,13 +77,6 @@ contract LazyOracle is ILazyOracle, AccessControlEnumerableUpgradeable {
         uint64 startTimestamp;
     }
 
-    struct QuarantineInfo {
-        bool isActive;
-        uint256 pendingTotalValueIncrease;
-        uint256 startTimestamp;
-        uint256 endTimestamp;
-    }
-
     struct VaultInfo {
         address vault;
         uint256 balance;

--- a/contracts/0.8.25/vaults/dashboard/NodeOperatorFee.sol
+++ b/contracts/0.8.25/vaults/dashboard/NodeOperatorFee.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.25;
 
 import {VaultHub} from "../VaultHub.sol";
 import {Permissions} from "./Permissions.sol";
+import {ILazyOracle} from "contracts/common/interfaces/ILazyOracle.sol";
 
 /**
  * @title NodeOperatorFee
@@ -201,6 +202,10 @@ contract NodeOperatorFee is Permissions {
         // Adjustment must be settled before the fee rate change
         if (rewardsAdjustment.amount != 0) revert AdjustmentNotSettled();
 
+        // If the vault is quarantined, the total value is reduced and may not reflect the adjustment
+        if (ILazyOracle(LIDO_LOCATOR.lazyOracle()).vaultQuarantine(address(_stakingVault())).isActive)
+            revert VaultQuarantined();
+
         // To follow the check-effects-interaction pattern, we need to remember the fee here
         // because the fee calculation variables will be reset in the following lines
         uint256 fee = nodeOperatorDisbursableFee();
@@ -375,4 +380,9 @@ contract NodeOperatorFee is Permissions {
      * @dev Error emitted when the adjustment is not settled.
      */
     error AdjustmentNotSettled();
+
+    /**
+     * @dev Error emitted when the vault is quarantined.
+     */
+    error VaultQuarantined();
 }

--- a/contracts/common/interfaces/ILazyOracle.sol
+++ b/contracts/common/interfaces/ILazyOracle.sol
@@ -10,9 +10,18 @@ pragma solidity ^0.8.9;
  * Interface to connect AccountingOracle with LazyOracle and force type consistency
  */
 interface ILazyOracle {
+    struct QuarantineInfo {
+        bool isActive;
+        uint256 pendingTotalValueIncrease;
+        uint256 startTimestamp;
+        uint256 endTimestamp;
+    }
+
     function updateReportData(
         uint256 _timestamp,
         bytes32 _vaultsDataTreeRoot,
         string memory _vaultsDataReportCid
     ) external;
+
+    function vaultQuarantine(address _vault) external view returns (QuarantineInfo memory);
 }

--- a/test/0.8.25/vaults/node-operator-fee/contracts/LazyOracle__MockForNodeOperatorFee.sol
+++ b/test/0.8.25/vaults/node-operator-fee/contracts/LazyOracle__MockForNodeOperatorFee.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+// for testing purposes only
+
+pragma solidity 0.8.25;
+
+import {ILazyOracle} from "contracts/common/interfaces/ILazyOracle.sol";
+
+contract LazyOracle__MockForNodeOperatorFee is ILazyOracle {
+    QuarantineInfo internal quarantineInfo;
+
+    function updateReportData(
+        uint256 _timestamp,
+        bytes32 _vaultsDataTreeRoot,
+        string memory _vaultsDataReportCid
+    ) external {}
+
+    function mock__setQuarantineInfo(QuarantineInfo memory _quarantineInfo) external {
+        quarantineInfo = _quarantineInfo;
+    }
+
+    function vaultQuarantine(address _vault) external view returns (QuarantineInfo memory) {
+        return quarantineInfo;
+    }
+}

--- a/test/0.8.25/vaults/node-operator-fee/node-operator-fee.test.ts
+++ b/test/0.8.25/vaults/node-operator-fee/node-operator-fee.test.ts
@@ -5,6 +5,7 @@ import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
 import {
+  LazyOracle__MockForNodeOperatorFee,
   LidoLocator,
   NodeOperatorFee__Harness,
   StakingVault__MockForNodeOperatorFee,
@@ -41,6 +42,7 @@ describe("NodeOperatorFee.sol", () => {
   let vault: StakingVault__MockForNodeOperatorFee;
   let nodeOperatorFee: NodeOperatorFee__Harness;
   let beacon: UpgradeableBeacon;
+  let lazyOracle: LazyOracle__MockForNodeOperatorFee;
 
   let originalState: string;
 
@@ -53,8 +55,14 @@ describe("NodeOperatorFee.sol", () => {
 
     steth = await ethers.deployContract("StETH__MockForNodeOperatorFee");
     wsteth = await ethers.deployContract("WstETH__HarnessForVault", [steth]);
+    lazyOracle = await ethers.deployContract("LazyOracle__MockForNodeOperatorFee");
 
-    lidoLocator = await deployLidoLocator({ lido: steth, wstETH: wsteth, predepositGuarantee: vaultDepositor });
+    lidoLocator = await deployLidoLocator({
+      lido: steth,
+      wstETH: wsteth,
+      predepositGuarantee: vaultDepositor,
+      lazyOracle,
+    });
     hub = await ethers.deployContract("VaultHub__MockForNodeOperatorFee", [lidoLocator, steth]);
 
     nodeOperatorFeeImpl = await ethers.deployContract("NodeOperatorFee__Harness", [hub, lidoLocator]);
@@ -655,6 +663,43 @@ describe("NodeOperatorFee.sol", () => {
       await expect(nodeOperatorFee.connect(vaultOwner).setNodeOperatorFeeRate(100n)).to.be.revertedWithCustomError(
         nodeOperatorFee,
         "AdjustmentNotReported",
+      );
+    });
+
+    it("reverts if the vault is quarantined", async () => {
+      // grant vaultOwner the NODE_OPERATOR_MANAGER_ROLE to set the fee rate
+      // to simplify the test
+      await nodeOperatorFee
+        .connect(nodeOperatorManager)
+        .grantRole(await nodeOperatorFee.NODE_OPERATOR_MANAGER_ROLE(), vaultOwner);
+
+      const noFeeRate = await nodeOperatorFee.nodeOperatorFeeRate();
+
+      const rewards = ether("1");
+
+      await hub.setReport(
+        {
+          totalValue: rewards,
+          inOutDelta: 0n,
+        },
+        await getCurrentBlockTimestamp(),
+        true,
+      );
+
+      const expectedFee = (rewards * noFeeRate) / BP_BASE;
+
+      expect(await nodeOperatorFee.nodeOperatorDisbursableFee()).to.equal(expectedFee);
+
+      await lazyOracle.mock__setQuarantineInfo({
+        isActive: true,
+        pendingTotalValueIncrease: 0,
+        startTimestamp: 0,
+        endTimestamp: 0,
+      });
+
+      await expect(nodeOperatorFee.connect(vaultOwner).setNodeOperatorFeeRate(100n)).to.be.revertedWithCustomError(
+        nodeOperatorFee,
+        "VaultQuarantined",
       );
     });
 

--- a/test/deploy/locator.ts
+++ b/test/deploy/locator.ts
@@ -33,6 +33,7 @@ async function deployDummyLocator(config?: Partial<LidoLocator.ConfigStruct>, de
     vaultHub: certainAddress("dummy-locator:vaultHub"),
     operatorGrid: certainAddress("dummy-locator:operatorGrid"),
     lazyOracle: certainAddress("dummy-locator:lazyOracle"),
+    vaultFactory: certainAddress("dummy-locator:vaultFactory"),
     ...config,
   });
 


### PR DESCRIPTION
Reverts NO operator fee change if the vault is in quarantine because the total value in the report may not reflect the adjustment.