### PR TITLE
try out heap tweak with IR

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,8 @@ jobs:
   coverage:
     name: Hardhat
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max_old_space_size=4096
 
     permissions:
       contents: write

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     name: Hardhat
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: --max_old_space_size=4096
+      NODE_OPTIONS: --max_old_space_size=6400
 
     permissions:
       contents: write


### PR DESCRIPTION
Bump Node.JS heap to withstand `hardhat coverage` memory consumption with `via-IR` enabled. 