### PR TITLE
Remove redundant zero check

### DIFF
--- a/contracts/0.8.25/ValidatorExitDelayVerifier.sol
+++ b/contracts/0.8.25/ValidatorExitDelayVerifier.sol
@@ -115,7 +115,6 @@ contract ValidatorExitDelayVerifier {
         uint256 provableBeaconBlockTimestamp,
         uint256 eligibleExitRequestTimestamp
     );
-    error EmptyDeliveryHistory();
     error InvalidCapellaSlot();
 
     /**

--- a/contracts/0.8.25/ValidatorExitDelayVerifier.sol
+++ b/contracts/0.8.25/ValidatorExitDelayVerifier.sol
@@ -394,10 +394,6 @@ contract ValidatorExitDelayVerifier {
     ) internal view returns (uint256 deliveryTimestamp) {
         bytes32 exitRequestsHash = keccak256(abi.encode(exitRequests.data, exitRequests.dataFormat));
         deliveryTimestamp = veb.getDeliveryTimestamp(exitRequestsHash);
-
-        if (deliveryTimestamp == 0) {
-            revert EmptyDeliveryHistory();
-        }
     }
 
     function _slotToTimestamp(uint64 slot) internal view returns (uint256) {

--- a/test/0.8.25/contracts/ValidatorsExitBusOracle_Mock.sol
+++ b/test/0.8.25/contracts/ValidatorsExitBusOracle_Mock.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 
 import {IValidatorsExitBus} from "contracts/0.8.25/interfaces/IValidatorsExitBus.sol";
 
+error RequestsNotDelivered();
+
 struct MockExitRequestData {
     bytes pubkey;
     uint256 nodeOpId;
@@ -32,6 +34,9 @@ contract ValidatorsExitBusOracle_Mock is IValidatorsExitBus {
 
     function getDeliveryTimestamp(bytes32 exitRequestsHash) external view returns (uint256 timestamp) {
         require(exitRequestsHash == _hash, "Mock error, Invalid exitRequestsHash");
+        if (_deliveryTimestamp == 0) {
+            revert RequestsNotDelivered();
+        }
         return _deliveryTimestamp;
     }
 

--- a/test/0.8.25/validatorExitDelayVerifier.test.ts
+++ b/test/0.8.25/validatorExitDelayVerifier.test.ts
@@ -547,7 +547,7 @@ describe("ValidatorExitDelayVerifier.sol", () => {
       ).to.be.reverted;
     });
 
-    it("reverts with 'EmptyDeliveryHistory' if exit request index is not in delivery history", async () => {
+    it("reverts with 'RequestsNotDelivered' if exit request index is not in delivery history", async () => {
       const exitRequests: ExitRequest[] = [
         {
           moduleId: 1,
@@ -565,7 +565,6 @@ describe("ValidatorExitDelayVerifier.sol", () => {
 
       // Report not unpacked, deliveryTimestamp == 0
       await vebo.setExitRequests(encodedExitRequestsHash, 0, exitRequests);
-      expect(await vebo.getDeliveryTimestamp(encodedExitRequestsHash)).to.equal(0);
 
       await expect(
         validatorExitDelayVerifier.verifyValidatorExitDelay(
@@ -573,7 +572,7 @@ describe("ValidatorExitDelayVerifier.sol", () => {
           [toValidatorWitness(ACTIVE_VALIDATOR_PROOF, unpackedExitRequestIndex)],
           encodedExitRequests,
         ),
-      ).to.be.revertedWithCustomError(validatorExitDelayVerifier, "EmptyDeliveryHistory");
+      ).to.be.revertedWithCustomError(vebo, "RequestsNotDelivered");
 
       await expect(
         validatorExitDelayVerifier.verifyHistoricalValidatorExitDelay(
@@ -582,7 +581,7 @@ describe("ValidatorExitDelayVerifier.sol", () => {
           [toValidatorWitness(ACTIVE_VALIDATOR_PROOF, unpackedExitRequestIndex)],
           encodedExitRequests,
         ),
-      ).to.be.revertedWithCustomError(validatorExitDelayVerifier, "EmptyDeliveryHistory");
+      ).to.be.revertedWithCustomError(vebo, "RequestsNotDelivered");
     });
 
     it("reverts if the oldBlock proof is corrupted", async () => {


### PR DESCRIPTION
Zero check in `_getExitRequestDeliveryTimestamp` is redundant.

## Context

`veb.getDeliveryTimestamp(exitRequestsHash)` makes same check.

## Problem

Redundant check.

## Solution

Removed the check.
