### PR TITLE
fix: vaultFactory.createVaultWithoutConnecting

### DIFF
--- a/contracts/0.8.25/vaults/VaultFactory.sol
+++ b/contracts/0.8.25/vaults/VaultFactory.sol
@@ -71,7 +71,7 @@ contract VaultFactory {
         vault.initialize(address(dashboard), _nodeOperator, locator.predepositGuarantee());
 
         // initialize Dashboard with the factory address as the default admin, grant optional roles and connect to VaultHub
-        dashboard.initialize(address(this), _nodeOperatorManager, _nodeOperatorFeeBP, _confirmExpiry);
+        dashboard.initialize(address(this), _nodeOperatorManager, _nodeOperatorManager, _nodeOperatorFeeBP, _confirmExpiry);
 
         if (_roleAssignments.length > 0) dashboard.grantRoles(_roleAssignments);
 
@@ -115,11 +115,10 @@ contract VaultFactory {
         vault.initialize(address(dashboard), _nodeOperator, locator.predepositGuarantee());
 
         // initialize Dashboard with the _defaultAdmin as the default admin, grant optional node operator managed roles
-        dashboard.initialize(_defaultAdmin, address(this), _nodeOperatorFeeBP, _confirmExpiry);
+        dashboard.initialize(_defaultAdmin, address(this), _nodeOperatorManager, _nodeOperatorFeeBP, _confirmExpiry);
 
         if (_roleAssignments.length > 0) dashboard.grantRoles(_roleAssignments);
 
-        dashboard.setNodeOperatorFeeRecipient(_nodeOperatorManager);
         dashboard.grantRole(dashboard.NODE_OPERATOR_MANAGER_ROLE(), _nodeOperatorManager);
         dashboard.revokeRole(dashboard.NODE_OPERATOR_MANAGER_ROLE(), address(this));
 

--- a/contracts/0.8.25/vaults/VaultFactory.sol
+++ b/contracts/0.8.25/vaults/VaultFactory.sol
@@ -101,7 +101,7 @@ contract VaultFactory {
         uint256 _nodeOperatorFeeBP,
         uint256 _confirmExpiry,
         Permissions.RoleAssignment[] calldata _roleAssignments
-    ) external payable returns (IStakingVault vault, Dashboard dashboard) {
+    ) external returns (IStakingVault vault, Dashboard dashboard) {
         ILidoLocator locator = ILidoLocator(LIDO_LOCATOR);
 
         // create the vault proxy
@@ -119,6 +119,7 @@ contract VaultFactory {
 
         if (_roleAssignments.length > 0) dashboard.grantRoles(_roleAssignments);
 
+        dashboard.setNodeOperatorFeeRecipient(_nodeOperatorManager);
         dashboard.grantRole(dashboard.NODE_OPERATOR_MANAGER_ROLE(), _nodeOperatorManager);
         dashboard.revokeRole(dashboard.NODE_OPERATOR_MANAGER_ROLE(), address(this));
 

--- a/contracts/0.8.25/vaults/dashboard/Dashboard.sol
+++ b/contracts/0.8.25/vaults/dashboard/Dashboard.sol
@@ -87,10 +87,11 @@ contract Dashboard is NodeOperatorFee {
     function initialize(
         address _defaultAdmin,
         address _nodeOperatorManager,
+        address _nodeOperatorFeeRecipient,
         uint256 _nodeOperatorFeeBP,
         uint256 _confirmExpiry
     ) external {
-        super._initialize(_defaultAdmin, _nodeOperatorManager, _nodeOperatorFeeBP, _confirmExpiry);
+        super._initialize(_defaultAdmin, _nodeOperatorManager, _nodeOperatorFeeRecipient, _nodeOperatorFeeBP, _confirmExpiry);
 
         // reduces gas cost for `mintWsteth`
         // invariant: dashboard does not hold stETH on its balance

--- a/contracts/0.8.25/vaults/dashboard/NodeOperatorFee.sol
+++ b/contracts/0.8.25/vaults/dashboard/NodeOperatorFee.sol
@@ -92,6 +92,7 @@ contract NodeOperatorFee is Permissions {
     function _initialize(
         address _defaultAdmin,
         address _nodeOperatorManager,
+        address _nodeOperatorFeeRecipient,
         uint256 _nodeOperatorFeeRate,
         uint256 _confirmExpiry
     ) internal {
@@ -101,7 +102,7 @@ contract NodeOperatorFee is Permissions {
 
         _validateNodeOperatorFeeRate(_nodeOperatorFeeRate);
         _setNodeOperatorFeeRate(_nodeOperatorFeeRate);
-        _setNodeOperatorFeeRecipient(_nodeOperatorManager);
+        _setNodeOperatorFeeRecipient(_nodeOperatorFeeRecipient);
 
         _grantRole(NODE_OPERATOR_MANAGER_ROLE, _nodeOperatorManager);
         _setRoleAdmin(NODE_OPERATOR_MANAGER_ROLE, NODE_OPERATOR_MANAGER_ROLE);

--- a/test/0.8.25/vaults/dashboard/dashboard.test.ts
+++ b/test/0.8.25/vaults/dashboard/dashboard.test.ts
@@ -295,13 +295,13 @@ describe("Dashboard.sol", () => {
 
     it("reverts if already initialized", async () => {
       await expect(
-        dashboard.initialize(vaultOwner, nodeOperator, nodeOperatorFeeBP, confirmExpiry),
+        dashboard.initialize(vaultOwner, nodeOperator, nodeOperator, nodeOperatorFeeBP, confirmExpiry),
       ).to.be.revertedWithCustomError(dashboard, "AlreadyInitialized");
     });
 
     it("reverts if called on the implementation", async () => {
       await expect(
-        dashboardImpl.initialize(vaultOwner, nodeOperator, nodeOperatorFeeBP, confirmExpiry),
+        dashboardImpl.initialize(vaultOwner, nodeOperator, nodeOperator, nodeOperatorFeeBP, confirmExpiry),
       ).to.be.revertedWithCustomError(dashboardImpl, "NonProxyCallsForbidden");
     });
   });

--- a/test/0.8.25/vaults/node-operator-fee/contracts/NodeOperatorFee__Harness.sol
+++ b/test/0.8.25/vaults/node-operator-fee/contracts/NodeOperatorFee__Harness.sol
@@ -15,6 +15,12 @@ contract NodeOperatorFee__Harness is NodeOperatorFee {
         uint256 _nodeOperatorFeeBP,
         uint256 _confirmExpiry
     ) external {
-        super._initialize(_defaultAdmin, _nodeOperatorManager, _nodeOperatorFeeBP, _confirmExpiry);
+        super._initialize(
+            _defaultAdmin,
+            _nodeOperatorManager,
+            _nodeOperatorManager,
+            _nodeOperatorFeeBP,
+            _confirmExpiry
+        );
     }
 }

--- a/test/0.8.25/vaults/vaultFactory.test.ts
+++ b/test/0.8.25/vaults/vaultFactory.test.ts
@@ -403,7 +403,7 @@ describe("VaultFactory.sol", () => {
 
   context("createVaultWithDashboardWithoutConnectingToVaultHub", () => {
     it("works with roles assigned to node operator", async () => {
-      const { vault } = await createVaultProxyWithoutConnectingToVaultHub(
+      const { vault, dashboard: _dashboard } = await createVaultProxyWithoutConnectingToVaultHub(
         vaultOwner1,
         vaultFactory,
         vaultOwner1,
@@ -419,14 +419,16 @@ describe("VaultFactory.sol", () => {
         ],
       );
 
-      const vaultConnection = await vaultHub.vaultConnection(vault);
+      // new instance of dashboard
+      const newDashboard = await ethers.getContractAt("Dashboard", await _dashboard.getAddress());
+      expect(await newDashboard.nodeOperatorFeeRecipient()).to.eq(operator.address);
 
-      expect(await dashboard.getAddress()).to.not.eq(vaultConnection.owner);
-      expect(vaultConnection.vaultIndex).to.eq(0);
+      const vaultConnection = await vaultHub.vaultConnection(vault);
+      expect(vaultConnection.vaultIndex).to.eq(0); // vault is not connected to the vaultHub
     });
 
     it("works with empty roles", async () => {
-      const { vault } = await createVaultProxyWithoutConnectingToVaultHub(
+      const { vault, dashboard: _dashboard } = await createVaultProxyWithoutConnectingToVaultHub(
         vaultOwner1,
         vaultFactory,
         vaultOwner1,
@@ -437,9 +439,11 @@ describe("VaultFactory.sol", () => {
         [],
       );
 
-      const vaultConnection = await vaultHub.vaultConnection(vault);
+      // new instance of dashboard
+      const newDashboard = await ethers.getContractAt("Dashboard", await _dashboard.getAddress());
+      expect(await newDashboard.nodeOperatorFeeRecipient()).to.eq(operator.address);
 
-      expect(await dashboard.getAddress()).to.not.eq(vaultConnection.owner);
+      const vaultConnection = await vaultHub.vaultConnection(vault);
       expect(vaultConnection.vaultIndex).to.eq(0);
     });
 


### PR DESCRIPTION
Fix issues:
- Incorrect nodeOperatorFeeRecipient in VaultFactory non-connected flow — [#1212](https://github.com/lidofinance/core/issues/1212)
- Unnecessary payable on VaultFactory.createVaultWithDashboardWithoutConnectingToVaultHub — [#1218](https://github.com/lidofinance/core/issues/1218)
