### PR TITLE
Require vault to be connected to update report data

### DIFF
--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -494,6 +494,7 @@ contract VaultHub is PausableUntilWithRoles {
         _requireSender(address(_lazyOracle()));
 
         VaultConnection storage connection = _vaultConnection(_vault);
+        _requireConnected(connection, _vault);
         VaultRecord storage record = _vaultRecord(_vault);
         VaultObligations storage obligations = _vaultObligations(_vault);
 

--- a/test/0.8.25/vaults/vaulthub/vaulthub.hub.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.hub.test.ts
@@ -1290,4 +1290,24 @@ describe("VaultHub.sol:hub", () => {
       expect(vaultSocket.pendingDisconnect).to.be.true;
     });
   });
+
+  context("applyVaultReport", () => {
+    it("reverts if called by non LazyOracle", async () => {
+      const { vault } = await createAndConnectVault(vaultFactory);
+      await expect(
+        vaultHub.connect(stranger).applyVaultReport(vault, 1n, 1n, 1n, 1n, 1n, 1n),
+      ).to.be.revertedWithCustomError(vaultHub, "NotAuthorized");
+    });
+
+    it("reverts if vault is not connected", async () => {
+      await lazyOracle.refreshReportTimestamp();
+      const { vault } = await createAndConnectVault(vaultFactory);
+
+      await vaultHub.connect(user).disconnect(vault);
+      await reportVault({ vault });
+      expect(await vaultHub.isVaultConnected(vault)).to.be.false;
+
+      await expect(reportVault({ vault })).to.be.revertedWithCustomError(vaultHub, "NotConnectedToHub");
+    });
+  });
 });

--- a/test/integration/vaults/pausable-beacon-deposits.integration.ts
+++ b/test/integration/vaults/pausable-beacon-deposits.integration.ts
@@ -123,6 +123,7 @@ describe("Integration: Vault hub beacon deposits pause flows", () => {
 
     it("Pause beacon deposits on setting redemptions obligations", async () => {
       await dashboard.connect(roles.funder).fund({ value: ether("1") });
+      await reportVaultDataWithProof(ctx, stakingVault, { totalValue: ether("100") });
       await dashboard.connect(roles.minter).mintShares(roles.burner, ether("1"));
 
       await expect(vaultHub.connect(redemptionMaster).setVaultRedemptions(stakingVaultAddress, ether("1"))).to.emit(


### PR DESCRIPTION
Require vault to be connected to update report data
Fixes https://github.com/lidofinance/core/issues/1271