### PR TITLE
fix: correct typos in test descriptions

### DIFF
--- a/test/0.4.24/steth.test.ts
+++ b/test/0.4.24/steth.test.ts
@@ -140,7 +140,7 @@ describe("StETH.sol:non-ERC-20 behavior", () => {
       );
     });
 
-    it("Reverts when transfering from zero address", async () => {
+    it("Reverts when transferring from zero address", async () => {
       await expect(steth.connect(zeroAddressSigner).transferShares(recipient, 0)).to.be.revertedWith(
         "TRANSFER_FROM_ZERO_ADDR",
       );
@@ -382,7 +382,7 @@ describe("StETH.sol:non-ERC-20 behavior", () => {
       ["positive", 105n], // 0.95
       ["negative", 95n], // 1.05
     ]) {
-      it(`The amount of shares is unchaged after a ${rebase} rebase`, async () => {
+      it(`The amount of shares is unchanged after a ${rebase} rebase`, async () => {
         const totalSharesBeforeRebase = await steth.getTotalShares();
 
         const rebasedSupply = (totalSupply * (factor as bigint)) / 100n;
@@ -399,7 +399,7 @@ describe("StETH.sol:non-ERC-20 behavior", () => {
       ["positive", 105n], // 0.95
       ["negative", 95n], // 1.05
     ]) {
-      it(`The amount of user shares is unchaged after a ${rebase} rebase`, async () => {
+      it(`The amount of user shares is unchanged after a ${rebase} rebase`, async () => {
         const sharesOfHolderBeforeRebase = await steth.sharesOf(holder);
 
         const rebasedSupply = (totalSupply * (factor as bigint)) / 100n;


### PR DESCRIPTION
## Summary
Fixes spelling errors in test descriptions within `test/0.4.24/steth.test.ts`.

## Changes
- **Line 143:** "transfering" → "transferring"
- **Line 385:** "unchaged" → "unchanged" 
- **Line 402:** "unchaged" → "unchanged"

