### PR TITLE
docs(lido): correct CL validators vs deposited validators comment in _getTransientBalance

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -1094,7 +1094,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
     function _getTransientBalance() internal view returns (uint256) {
         uint256 depositedValidators = DEPOSITED_VALIDATORS_POSITION.getStorageUint256();
         uint256 clValidators = CL_VALIDATORS_POSITION.getStorageUint256();
-        // clValidators can never be less than deposited ones.
+        // clValidators can never exceed depositedValidators.
         assert(depositedValidators >= clValidators);
         return (depositedValidators - clValidators).mul(DEPOSIT_SIZE);
     }


### PR DESCRIPTION
Update comment to state “clValidators can never exceed depositedValidators,” aligning docs with the existing assertion assert(depositedValidators >= clValidators).
Rationale: deposited validators can be in a transient state (submitted to Deposit contract but not yet active on CL), so deposited can be greater than CL validators.
refs #1364 