### PR TITLE
[VAULTS] Track unresolved validators in PDG to prevent pessimistic baddebt internalization

### DIFF
--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -593,6 +593,10 @@ contract VaultHub is PausableUntilWithRoles {
         VaultConnection storage badDebtConnection = _vaultConnection(_badDebtVault);
         _requireConnected(badDebtConnection, _badDebtVault);
 
+        if (IPredepositGuarantee(_predepositGuarantee()).unresolvedValidators(_badDebtVault) > 0) {
+            revert UnresolvedValidatorsAssociatedWithStakingVault();
+        }
+
         uint256 badDebtToInternalize = _writeOffBadDebt({
             _vault: _badDebtVault,
             _record: _vaultRecord(_badDebtVault),
@@ -1697,4 +1701,5 @@ contract VaultHub is PausableUntilWithRoles {
     error ForcedValidatorExitNotAllowed();
     error NoBadDebtToWriteOff(address vault, uint256 totalValueShares, uint256 liabilityShares);
     error BadDebtSocializationNotAllowed();
+    error UnresolvedValidatorsAssociatedWithStakingVault();
 }

--- a/contracts/0.8.25/vaults/interfaces/IPredepositGuarantee.sol
+++ b/contracts/0.8.25/vaults/interfaces/IPredepositGuarantee.sol
@@ -32,4 +32,6 @@ interface IPredepositGuarantee {
     }
 
     function proveUnknownValidator(ValidatorWitness calldata _witness, IStakingVault _stakingVault) external;
+
+    function unresolvedValidators(address _stakingVault) external view returns (uint256);
 }


### PR DESCRIPTION
Context
https://github.com/lidofinance/core/issues/1267