### PR TITLE
feat(tw-deploy): gateseal state and network state var

### DIFF
--- a/deployed-mainnet.json
+++ b/deployed-mainnet.json
@@ -15,7 +15,7 @@
     },
     "implementation": {
       "contract": "contracts/0.8.9/oracle/AccountingOracle.sol",
-      "address": "0x0e65898527E77210fB0133D00dd4C0E86Dc29bC7",
+      "address": "0x409466e099CC4F9b3929967a64036EBD257fCE30",
       "constructorArgs": [
         "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
         "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
@@ -114,7 +114,7 @@
     },
     "implementation": {
       "contract": "contracts/0.4.24/nos/NodeOperatorsRegistry.sol",
-      "address": "0x1770044a38402e3CfCa2Fcfa0C84a093c9B42135",
+      "address": "0x063A1D1Cfc6354FB21dC6DE6fBe4B748cbD01941",
       "constructorArgs": []
     },
     "aragonApp": {
@@ -190,9 +190,7 @@
     "implementation": {
       "contract": "@aragon/os/contracts/kernel/Kernel.sol",
       "address": "0x2b33CF282f867A7FF693A66e11B0FcC5552e4425",
-      "constructorArgs": [
-        true
-      ]
+      "constructorArgs": [true]
     },
     "proxy": {
       "address": "0xb8FFC3Cd6e7Cf5a098A1c92F48009765B24088Dc",
@@ -262,6 +260,16 @@
       "pauseIntentValidityPeriodBlocks": 6646
     }
   },
+  "dg:dualGovernance": {
+    "proxy": {
+      "address": "0xcdF49b058D606AD34c5789FD8c3BF8B3E54bA2db"
+    }
+  },
+  "dg:emergencyProtectedTimelock": {
+    "proxy": {
+      "address": "0xCE0425301C85c5Ea2A0873A2dEe44d78E02D2316"
+    }
+  },
   "dummyEmptyContract": {
     "address": "0x6F6541C2203196fEeDd14CD2C09550dA1CbEDa31",
     "contract": "contracts/0.8.9/utils/DummyEmptyContract.sol",
@@ -272,15 +280,27 @@
     "address": "0x8F73e4C2A6D852bb4ab2A45E6a9CF5715b3228B7",
     "contract": "contracts/0.8.9/EIP712StETH.sol",
     "deployTx": "0xecb5010620fb13b0e2bbc98b8a0c82de0d7385491452cd36cf303cd74216ed91",
-    "constructorArgs": [
-      "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
-    ]
+    "constructorArgs": ["0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"]
   },
   "ensAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
   "executionLayerRewardsVault": {
     "address": "0x388C818CA8B9251b393131C08a736A67ccB19297",
     "contract": "contracts/0.8.9/LidoExecutionLayerRewardsVault.sol",
     "deployTx": "0xd72cf25e4a5fe3677b6f9b2ae13771e02ad66f8d2419f333bb8bde3147bd4294"
+  },
+  "gateSeal": {
+    "address": "0x8A854C4E750CDf24f138f34A9061b2f556066912",
+    "factoryAddress": "0x6c82877cac5a7a739f16ca0a89c0a328b8764a24",
+    "sealDuration": 1209600,
+    "expiryTimestamp": 1787816411,
+    "sealingCommittee": "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C"
+  },
+  "gateSealTW": {
+    "factoryAddress": "0x6c82877cac5a7a739f16ca0a89c0a328b8764a24",
+    "sealDuration": 1209600,
+    "expiryTimestamp": 1787816411,
+    "sealingCommittee": "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C",
+    "address": "0xA6BC802fAa064414AA62117B4a53D27fFfF741F1"
   },
   "hashConsensusForAccountingOracle": {
     "address": "0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
@@ -338,7 +358,7 @@
     },
     "implementation": {
       "contract": "contracts/0.8.9/LidoLocator.sol",
-      "address": "0x3ABc4764f0237923d52056CFba7E9AEBf87113D3",
+      "address": "0xf13B5b418fffd2a1D6aAe3bE750D411Fa3AfF10d",
       "constructorArgs": [
         [
           "0x852deD011285fe67063a08005c71a85690503Cee",
@@ -354,7 +374,9 @@
           "0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e",
           "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
           "0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f",
-          "0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09"
+          "0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09",
+          "0xA6b6bAe20a4A11CdeE202DbdE53e89E776f2dAC9",
+          "0x6d7EFb67236AaAeC2005ec704Bf5d755dd0703c4"
         ]
       ]
     }
@@ -384,10 +406,7 @@
     "address": "0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09",
     "contract": "contracts/0.8.9/OracleDaemonConfig.sol",
     "deployTx": "0xa4f380b8806f5a504ef67fce62989e09be5a48bf114af63483c01c22f0c9a36f",
-    "constructorArgs": [
-      "0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5",
-      []
-    ],
+    "constructorArgs": ["0x8Ea83AD72396f1E0cD2f8E72b1461db8Eb6aF7B5", []],
     "deployParameters": {
       "NORMALIZED_CL_REWARD_PER_EPOCH": 64,
       "NORMALIZED_CL_REWARD_MISTAKE_RATE_BP": 1000,
@@ -407,20 +426,7 @@
     "constructorArgs": [
       "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
       "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
-      [
-        9000,
-        43200,
-        1000,
-        50,
-        600,
-        8,
-        24,
-        7680,
-        750000,
-        1000,
-        101,
-        50
-      ]
+      [9000, 43200, 1000, 50, 600, 8, 24, 7680, 750000, 1000, 101, 50]
     ],
     "deployParameters": {
       "churnValidatorsPerDayLimit": 20000,
@@ -434,6 +440,7 @@
       "maxPositiveTokenRebase": 750000
     }
   },
+  "scratchDeployGasUsed": "126395873",
   "stakingRouter": {
     "proxy": {
       "address": "0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
@@ -447,9 +454,45 @@
     },
     "implementation": {
       "contract": "contracts/0.8.9/StakingRouter.sol",
-      "address": "0x89eDa99C0551d4320b56F82DDE8dF2f8D2eF81aA",
+      "address": "0xbd605Ad2010E12c16B0cd0F2B8FE3c6d90BB51E7",
+      "constructorArgs": ["0x00000000219ab540356cBB839Cbe05303d7705Fa"]
+    }
+  },
+  "triggerableWithdrawalsGateway": {
+    "implementation": {
+      "contract": "contracts/0.8.9/TriggerableWithdrawalsGateway.sol",
+      "address": "0x6d7EFb67236AaAeC2005ec704Bf5d755dd0703c4",
       "constructorArgs": [
-        "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+        11200,
+        1,
+        48
+      ]
+    }
+  },
+  "validatorExitDelayVerifier": {
+    "implementation": {
+      "contract": "contracts/0.8.25/ValidatorExitDelayVerifier.sol",
+      "address": "0xA6b6bAe20a4A11CdeE202DbdE53e89E776f2dAC9",
+      "constructorArgs": [
+        "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+        {
+          "gIFirstValidatorPrev": "0x0000000000000000000000000000000000000000000000000096000000000028",
+          "gIFirstValidatorCurr": "0x0000000000000000000000000000000000000000000000000096000000000028",
+          "gIFirstHistoricalSummaryPrev": "0x000000000000000000000000000000000000000000000000000000b600000018",
+          "gIFirstHistoricalSummaryCurr": "0x000000000000000000000000000000000000000000000000000000b600000018",
+          "gIFirstBlockRootInSummaryPrev": "0x000000000000000000000000000000000000000000000000000000000040000d",
+          "gIFirstBlockRootInSummaryCurr": "0x000000000000000000000000000000000000000000000000000000000040000d"
+        },
+        1,
+        1,
+        0,
+        8192,
+        32,
+        12,
+        1606824023,
+        98304
       ]
     }
   },
@@ -465,17 +508,9 @@
       ]
     },
     "implementation": {
-      "address": "0xA89Ea51FddE660f67d1850e03C9c9862d33Bc42c",
       "contract": "contracts/0.8.9/oracle/ValidatorsExitBusOracle.sol",
-      "deployTx": "0x5ab545276f78a72a432c3e971c96384973abfab6394e08cb077a006c25aef7a7",
-      "constructorArgs": [
-        12,
-        1606824023,
-        "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"
-      ],
-      "deployParameters": {
-        "consensusVersion": 1
-      }
+      "address": "0x2107c6AC639F21F27D38C1b048C825Ee42536690",
+      "constructorArgs": [12, 1606824023, "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"]
     }
   },
   "vestingParams": {
@@ -562,11 +597,7 @@
       "address": "0xE42C659Dc09109566720EA8b2De186c2Be7D94D9",
       "contract": "contracts/0.8.9/WithdrawalQueueERC721.sol",
       "deployTx": "0x6ab0151735c01acdef518421358d41a08752169bc383c57d57f5bfa135ac6eb1",
-      "constructorArgs": [
-        "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-        "Lido: stETH Withdrawal NFT",
-        "unstETH"
-      ],
+      "constructorArgs": ["0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0", "Lido: stETH Withdrawal NFT", "unstETH"],
       "deployParameters": {
         "name": "Lido: stETH Withdrawal NFT",
         "symbol": "unstETH"
@@ -578,12 +609,12 @@
       "address": "0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f"
     },
     "implementation": {
-      "address": "0xCC52f17756C04bBa7E377716d7062fC36D7f69Fd",
       "contract": "contracts/0.8.9/WithdrawalVault.sol",
-      "deployTx": "0xd9eb2eca684770e4d2b192709b6071875f75072a0ce794a582824ee907a704f3",
+      "address": "0xc44C2b82dbEef6DdB195E0432Fa5e755C345D1e3",
       "constructorArgs": [
         "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
-        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
+        "0x6d7EFb67236AaAeC2005ec704Bf5d755dd0703c4"
       ]
     }
   },
@@ -591,18 +622,6 @@
     "address": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
     "contract": "contracts/0.6.12/WstETH.sol",
     "deployTx": "0xaf2c1a501d2b290ef1e84ddcfc7beb3406f8ece2c46dee14e212e8233654ff05",
-    "constructorArgs": [
-      "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
-    ]
-  },
-  "dg:dualGovernance": {
-    "proxy": {
-      "address": "0xcdF49b058D606AD34c5789FD8c3BF8B3E54bA2db"
-    }
-  },
-  "dg:emergencyProtectedTimelock": {
-    "proxy": {
-      "address": "0xCE0425301C85c5Ea2A0873A2dEe44d78E02D2316"
-    }
+    "constructorArgs": ["0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"]
   }
 }

--- a/deployed-mainnet.json
+++ b/deployed-mainnet.json
@@ -15,7 +15,7 @@
     },
     "implementation": {
       "contract": "contracts/0.8.9/oracle/AccountingOracle.sol",
-      "address": "0x409466e099CC4F9b3929967a64036EBD257fCE30",
+      "address": "0x0e65898527E77210fB0133D00dd4C0E86Dc29bC7",
       "constructorArgs": [
         "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
         "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
@@ -114,7 +114,7 @@
     },
     "implementation": {
       "contract": "contracts/0.4.24/nos/NodeOperatorsRegistry.sol",
-      "address": "0x063A1D1Cfc6354FB21dC6DE6fBe4B748cbD01941",
+      "address": "0x1770044a38402e3CfCa2Fcfa0C84a093c9B42135",
       "constructorArgs": []
     },
     "aragonApp": {
@@ -260,16 +260,6 @@
       "pauseIntentValidityPeriodBlocks": 6646
     }
   },
-  "dg:dualGovernance": {
-    "proxy": {
-      "address": "0xcdF49b058D606AD34c5789FD8c3BF8B3E54bA2db"
-    }
-  },
-  "dg:emergencyProtectedTimelock": {
-    "proxy": {
-      "address": "0xCE0425301C85c5Ea2A0873A2dEe44d78E02D2316"
-    }
-  },
   "dummyEmptyContract": {
     "address": "0x6F6541C2203196fEeDd14CD2C09550dA1CbEDa31",
     "contract": "contracts/0.8.9/utils/DummyEmptyContract.sol",
@@ -289,18 +279,11 @@
     "deployTx": "0xd72cf25e4a5fe3677b6f9b2ae13771e02ad66f8d2419f333bb8bde3147bd4294"
   },
   "gateSeal": {
-    "address": "0x8A854C4E750CDf24f138f34A9061b2f556066912",
+    "address": "0xf9C9fDB4A5D2AA1D836D5370AB9b28BC1847e178",
     "factoryAddress": "0x6c82877cac5a7a739f16ca0a89c0a328b8764a24",
-    "sealDuration": 1209600,
-    "expiryTimestamp": 1787816411,
+    "sealDuration": 950400,
+    "expiryTimestamp": 1772323200,
     "sealingCommittee": "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C"
-  },
-  "gateSealTW": {
-    "factoryAddress": "0x6c82877cac5a7a739f16ca0a89c0a328b8764a24",
-    "sealDuration": 1209600,
-    "expiryTimestamp": 1787816411,
-    "sealingCommittee": "0x8772E3a2D86B9347A2688f9bc1808A6d8917760C",
-    "address": "0xA6BC802fAa064414AA62117B4a53D27fFfF741F1"
   },
   "hashConsensusForAccountingOracle": {
     "address": "0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
@@ -358,7 +341,7 @@
     },
     "implementation": {
       "contract": "contracts/0.8.9/LidoLocator.sol",
-      "address": "0xf13B5b418fffd2a1D6aAe3bE750D411Fa3AfF10d",
+      "address": "0x3ABc4764f0237923d52056CFba7E9AEBf87113D3",
       "constructorArgs": [
         [
           "0x852deD011285fe67063a08005c71a85690503Cee",
@@ -374,9 +357,7 @@
           "0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e",
           "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
           "0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f",
-          "0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09",
-          "0xA6b6bAe20a4A11CdeE202DbdE53e89E776f2dAC9",
-          "0x6d7EFb67236AaAeC2005ec704Bf5d755dd0703c4"
+          "0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09"
         ]
       ]
     }
@@ -440,7 +421,6 @@
       "maxPositiveTokenRebase": 750000
     }
   },
-  "scratchDeployGasUsed": "126395873",
   "stakingRouter": {
     "proxy": {
       "address": "0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
@@ -454,46 +434,8 @@
     },
     "implementation": {
       "contract": "contracts/0.8.9/StakingRouter.sol",
-      "address": "0xbd605Ad2010E12c16B0cd0F2B8FE3c6d90BB51E7",
+      "address": "0x89eDa99C0551d4320b56F82DDE8dF2f8D2eF81aA",
       "constructorArgs": ["0x00000000219ab540356cBB839Cbe05303d7705Fa"]
-    }
-  },
-  "triggerableWithdrawalsGateway": {
-    "implementation": {
-      "contract": "contracts/0.8.9/TriggerableWithdrawalsGateway.sol",
-      "address": "0x6d7EFb67236AaAeC2005ec704Bf5d755dd0703c4",
-      "constructorArgs": [
-        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
-        "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
-        11200,
-        1,
-        48
-      ]
-    }
-  },
-  "validatorExitDelayVerifier": {
-    "implementation": {
-      "contract": "contracts/0.8.25/ValidatorExitDelayVerifier.sol",
-      "address": "0xA6b6bAe20a4A11CdeE202DbdE53e89E776f2dAC9",
-      "constructorArgs": [
-        "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
-        {
-          "gIFirstValidatorPrev": "0x0000000000000000000000000000000000000000000000000096000000000028",
-          "gIFirstValidatorCurr": "0x0000000000000000000000000000000000000000000000000096000000000028",
-          "gIFirstHistoricalSummaryPrev": "0x000000000000000000000000000000000000000000000000000000b600000018",
-          "gIFirstHistoricalSummaryCurr": "0x000000000000000000000000000000000000000000000000000000b600000018",
-          "gIFirstBlockRootInSummaryPrev": "0x000000000000000000000000000000000000000000000000000000000040000d",
-          "gIFirstBlockRootInSummaryCurr": "0x000000000000000000000000000000000000000000000000000000000040000d"
-        },
-        1,
-        1,
-        0,
-        8192,
-        32,
-        12,
-        1606824023,
-        98304
-      ]
     }
   },
   "validatorsExitBusOracle": {
@@ -508,9 +450,13 @@
       ]
     },
     "implementation": {
+      "address": "0xA89Ea51FddE660f67d1850e03C9c9862d33Bc42c",
       "contract": "contracts/0.8.9/oracle/ValidatorsExitBusOracle.sol",
-      "address": "0x2107c6AC639F21F27D38C1b048C825Ee42536690",
-      "constructorArgs": [12, 1606824023, "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"]
+      "deployTx": "0x5ab545276f78a72a432c3e971c96384973abfab6394e08cb077a006c25aef7a7",
+      "constructorArgs": [12, 1606824023, "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb"],
+      "deployParameters": {
+        "consensusVersion": 1
+      }
     }
   },
   "vestingParams": {
@@ -609,13 +555,10 @@
       "address": "0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f"
     },
     "implementation": {
+      "address": "0xCC52f17756C04bBa7E377716d7062fC36D7f69Fd",
       "contract": "contracts/0.8.9/WithdrawalVault.sol",
-      "address": "0xc44C2b82dbEef6DdB195E0432Fa5e755C345D1e3",
-      "constructorArgs": [
-        "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
-        "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
-        "0x6d7EFb67236AaAeC2005ec704Bf5d755dd0703c4"
-      ]
+      "deployTx": "0xd9eb2eca684770e4d2b192709b6071875f75072a0ce794a582824ee907a704f3",
+      "constructorArgs": ["0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84", "0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
     }
   },
   "wstETH": {
@@ -623,5 +566,15 @@
     "contract": "contracts/0.6.12/WstETH.sol",
     "deployTx": "0xaf2c1a501d2b290ef1e84ddcfc7beb3406f8ece2c46dee14e212e8233654ff05",
     "constructorArgs": ["0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"]
+  },
+  "dg:dualGovernance": {
+    "proxy": {
+      "address": "0xcdF49b058D606AD34c5789FD8c3BF8B3E54bA2db"
+    }
+  },
+  "dg:emergencyProtectedTimelock": {
+    "proxy": {
+      "address": "0xCE0425301C85c5Ea2A0873A2dEe44d78E02D2316"
+    }
   }
 }

--- a/scripts/tw-deploy.sh
+++ b/scripts/tw-deploy.sh
@@ -11,7 +11,7 @@ export DEPLOYER=${DEPLOYER:="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"}  # fir
 export GAS_PRIORITY_FEE=1
 export GAS_MAX_FEE=100
 
-export NETWORK_STATE_FILE="deployed-hoodi.json"
+export NETWORK_STATE_FILE=${NETWORK_STATE_FILE:="deployed-hoodi.json"}
 # export NETWORK_STATE_DEFAULTS_FILE="scripts/scratch/deployed-testnet-defaults.json"
 
 


### PR DESCRIPTION
Adding gateseal state to the mainnet state.

Adding network state variable for TW deploy script.

## Context

Prepration for TW mainnet deploy.

## Problem

- TW deploy script relies on presence of gateseal state in hardhat config.
- TW deploy script will need to have a path to the sate json as an argument.

