### PR TITLE
fix: error on stepsFile

### DIFF
--- a/scripts/utils/migrate.ts
+++ b/scripts/utils/migrate.ts
@@ -17,5 +17,5 @@ if (require.main === module) {
     process.exit(1);
   }
 
-  runMigrations(stepsFile).catch(() => process.exit(1));
+  runMigrations(stepsFile!).catch(() => process.exit(1));
 }


### PR DESCRIPTION
## Context

`runMigrations` is called with `stepsFile`, which we check exists right before.

## Problem

TS still thinks `stepsFile` might be `undefined`, causing a type error.

## Solution

added a non-null assertion (`!`) to `stepsFile` when calling `runMigrations` to clear the type error.
