### PR TITLE
fix: rebalance bug when totalPooledETH/totalShares < 1

### DIFF
--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -741,6 +741,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
 
     /**
      * @notice Transfer ether to the buffer decreasing the number of external shares in the same time
+     * @param _amountOfShares Amount of external shares to burn
      * @dev it's an equivalent of using `submit` and then `burnExternalShares`
      * but without any limits or pauses
      *
@@ -751,8 +752,8 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         _auth(_vaultHub());
         _whenNotStopped();
 
-        if (msg.value < Math256.ceilDiv(_amountOfShares *  _getTotalPooledEther(), _getTotalShares())) {
-            revert("INSUFFICIENT_ETHER");
+        if (msg.value != getPooledEthBySharesRoundUp(_amountOfShares)) {
+            revert("VALUE_SHARES_MISMATCH");
         }
 
         uint256 externalShares = _getExternalShares();

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -746,18 +746,21 @@ contract Lido is Versioned, StETHPermit, AragonApp {
      *
      * - msg.value is transferred to the buffer
      */
-    function rebalanceExternalEtherToInternal() external payable {
+    function rebalanceExternalEtherToInternal(uint256 _amountOfShares) external payable {
         require(msg.value != 0, "ZERO_VALUE");
         _auth(_vaultHub());
         _whenNotStopped();
 
-        uint256 amountOfShares = getSharesByPooledEth(msg.value);
+        uint256 calculatedAmountOfShares = getSharesByPooledEth(msg.value);
+        if (calculatedAmountOfShares != _amountOfShares + (_getTotalShares() - 1) / _getTotalPooledEther()) {
+            revert("INVALID_AMOUNT_OF_SHARES");
+        }
         uint256 externalShares = _getExternalShares();
 
-        if (externalShares < amountOfShares) revert("EXT_SHARES_TOO_SMALL");
+        if (externalShares < _amountOfShares) revert("EXT_SHARES_TOO_SMALL");
 
         // here the external balance is decreased (totalShares remains the same)
-        _setExternalShares(externalShares - amountOfShares);
+        _setExternalShares(externalShares - _amountOfShares);
 
         // here the buffer is increased
         _setBufferedEther(_getBufferedEther() + msg.value);
@@ -766,7 +769,7 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         // but it's not worth then using submit for it,
         // so invariants are the same
         emit ExternalEtherTransferredToBuffer(msg.value);
-        emit ExternalSharesBurnt(amountOfShares);
+        emit ExternalSharesBurnt(_amountOfShares);
     }
 
     /**

--- a/contracts/0.4.24/Lido.sol
+++ b/contracts/0.4.24/Lido.sol
@@ -751,10 +751,10 @@ contract Lido is Versioned, StETHPermit, AragonApp {
         _auth(_vaultHub());
         _whenNotStopped();
 
-        uint256 calculatedAmountOfShares = getSharesByPooledEth(msg.value);
-        if (calculatedAmountOfShares != _amountOfShares + (_getTotalShares() - 1) / _getTotalPooledEther()) {
-            revert("INVALID_AMOUNT_OF_SHARES");
+        if (msg.value < Math256.ceilDiv(_amountOfShares *  _getTotalPooledEther(), _getTotalShares())) {
+            revert("INSUFFICIENT_ETHER");
         }
+
         uint256 externalShares = _getExternalShares();
 
         if (externalShares < _amountOfShares) revert("EXT_SHARES_TOO_SMALL");

--- a/contracts/0.8.25/vaults/VaultHub.sol
+++ b/contracts/0.8.25/vaults/VaultHub.sol
@@ -1024,7 +1024,7 @@ contract VaultHub is PausableUntilWithRoles {
 
         _decreaseLiability(_vault, _record, _shares);
         _withdraw(_vault, _record, address(this), valueToRebalance);
-        _rebalanceExternalEtherToInternal(valueToRebalance);
+        _rebalanceExternalEtherToInternal(valueToRebalance, _shares);
 
         _updateBeaconChainDepositsPause(_vault, _record, _vaultConnection(_vault));
 
@@ -1421,8 +1421,8 @@ contract VaultHub is PausableUntilWithRoles {
         return LIDO.getPooledEthBySharesRoundUp(_shares);
     }
 
-    function _rebalanceExternalEtherToInternal(uint256 _ether) internal {
-        LIDO.rebalanceExternalEtherToInternal{value: _ether}();
+    function _rebalanceExternalEtherToInternal(uint256 _ether, uint256 _amountOfShares) internal {
+        LIDO.rebalanceExternalEtherToInternal{value: _ether}(_amountOfShares);
     }
 
     function _triggerVaultValidatorWithdrawals(

--- a/contracts/common/interfaces/ILido.sol
+++ b/contracts/common/interfaces/ILido.sol
@@ -22,7 +22,7 @@ interface ILido is IERC20, IVersioned {
 
     function transferShares(address, uint256) external returns (uint256);
 
-    function rebalanceExternalEtherToInternal() external payable;
+    function rebalanceExternalEtherToInternal(uint256 _amountOfShares) external payable;
 
     function getTotalPooledEther() external view returns (uint256);
 

--- a/test/0.4.24/lido/lido.externalShares.test.ts
+++ b/test/0.4.24/lido/lido.externalShares.test.ts
@@ -337,20 +337,22 @@ describe("Lido.sol:externalShares", () => {
 
   context("rebalanceExternalEtherToInternal", () => {
     it("Reverts if amount of shares is zero", async () => {
-      await expect(lido.connect(user).rebalanceExternalEtherToInternal()).to.be.revertedWith("ZERO_VALUE");
+      await expect(lido.connect(user).rebalanceExternalEtherToInternal(0n)).to.be.revertedWith("ZERO_VALUE");
     });
 
     it("Reverts if not authorized", async () => {
-      await expect(lido.connect(user).rebalanceExternalEtherToInternal({ value: 1n })).to.be.revertedWith(
+      await expect(lido.connect(user).rebalanceExternalEtherToInternal(0n, { value: 1n })).to.be.revertedWith(
         "APP_AUTH_FAILED",
       );
     });
 
     it("Reverts if amount of ether is greater than minted shares", async () => {
+      const amountETH = await lido.getPooledEthBySharesRoundUp(1n);
+      const totalShares = await lido.getTotalShares();
+      const totalPooledETH = await lido.getTotalPooledEther();
+      const shares = (amountETH * totalShares) / totalPooledETH;
       await expect(
-        lido
-          .connect(vaultHubSigner)
-          .rebalanceExternalEtherToInternal({ value: await lido.getPooledEthBySharesRoundUp(1n) }),
+        lido.connect(vaultHubSigner).rebalanceExternalEtherToInternal(shares, { value: amountETH }),
       ).to.be.revertedWith("EXT_SHARES_TOO_SMALL");
     });
 
@@ -363,13 +365,27 @@ describe("Lido.sol:externalShares", () => {
       const bufferedEtherBefore = await lido.getBufferedEther();
 
       const etherToRebalance = await lido.getPooledEthBySharesRoundUp(1n);
-
-      await lido.connect(vaultHubSigner).rebalanceExternalEtherToInternal({
+      const totalShares = await lido.getTotalShares();
+      const totalPooledETH = await lido.getTotalPooledEther();
+      const shares = (etherToRebalance * totalShares) / totalPooledETH;
+      await lido.connect(vaultHubSigner).rebalanceExternalEtherToInternal(shares, {
         value: etherToRebalance,
       });
 
       expect(await lido.getExternalShares()).to.equal(amountToMint - 1n);
       expect(await lido.getBufferedEther()).to.equal(bufferedEtherBefore + etherToRebalance);
+    });
+
+    it("Reverts if amount of ether is less than required", async () => {
+      const amountOfShares = 10n;
+      const totalPooledETH = await lido.getTotalPooledEther();
+      const totalShares = await lido.getTotalShares();
+      const etherToRebalance = (amountOfShares * totalPooledETH - 1n) / totalShares + 1n; // roundUp
+      await expect(
+        lido.connect(vaultHubSigner).rebalanceExternalEtherToInternal(amountOfShares, {
+          value: etherToRebalance - 1n, // less than required
+        }),
+      ).to.be.revertedWith("INSUFFICIENT_ETHER");
     });
   });
 

--- a/test/0.4.24/lido/lido.externalShares.test.ts
+++ b/test/0.4.24/lido/lido.externalShares.test.ts
@@ -385,7 +385,7 @@ describe("Lido.sol:externalShares", () => {
         lido.connect(vaultHubSigner).rebalanceExternalEtherToInternal(amountOfShares, {
           value: etherToRebalance - 1n, // less than required
         }),
-      ).to.be.revertedWith("INSUFFICIENT_ETHER");
+      ).to.be.revertedWith("VALUE_SHARES_MISMATCH");
     });
   });
 

--- a/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
@@ -566,8 +566,11 @@ describe("VaultHub.sol:owner-functions", () => {
       const liabilitySharesBeforeRebalance = await vaultHub.liabilityShares(vaultAddress);
       expect(externalSharesBeforeRebalance).to.equal(liabilitySharesBeforeRebalance);
 
+      const totalPooledEtherAfterMint = await lido.getTotalPooledEther();
+      const totalSharesAfterMint = await lido.getTotalShares();
+
       const rebalanceAmountShares = ether("0.1");
-      const eth = (rebalanceAmountShares * totalPooledEther - 1n) / totalShares + 1n; // roundUp
+      const eth = (rebalanceAmountShares * totalPooledEtherAfterMint - 1n) / totalSharesAfterMint + 1n; // roundUp
       await expect(vaultHub.connect(vaultOwner).rebalance(vaultAddress, rebalanceAmountShares))
         .to.emit(vaultHub, "VaultRebalanced")
         .withArgs(vaultAddress, rebalanceAmountShares, eth);

--- a/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
+++ b/test/0.8.25/vaults/vaulthub/vaulthub.vault.test.ts
@@ -568,6 +568,7 @@ describe("VaultHub.sol:owner-functions", () => {
 
       const totalPooledEtherAfterMint = await lido.getTotalPooledEther();
       const totalSharesAfterMint = await lido.getTotalShares();
+      expect(totalPooledEtherAfterMint).to.lessThan(totalSharesAfterMint);
 
       const rebalanceAmountShares = ether("0.1");
       const eth = (rebalanceAmountShares * totalPooledEtherAfterMint - 1n) / totalSharesAfterMint + 1n; // roundUp


### PR DESCRIPTION
Fixes [#1244](https://github.com/lidofinance/core/issues/1244)