### PR TITLE
feat: shortfall rework

### DIFF
--- a/test/deploy/vaults.ts
+++ b/test/deploy/vaults.ts
@@ -81,7 +81,7 @@ async function createMockStakingVaultAndConnect(
   return vault;
 }
 
-async function reportVault(
+export async function reportVault(
   lazyOracle: LazyOracle__MockForVaultHub,
   vaultHub: VaultHub,
   {

--- a/test/integration/vaults/vaulthub.shortfall.integration.ts
+++ b/test/integration/vaults/vaulthub.shortfall.integration.ts
@@ -1,0 +1,189 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+import { Dashboard, StakingVault, VaultHub } from "typechain-types";
+
+import { impersonate } from "lib";
+import {
+  calculateLockedValue,
+  createVaultWithDashboard,
+  getProtocolContext,
+  ProtocolContext,
+  setupLidoForVaults,
+} from "lib/protocol";
+import { reportVaultDataWithProof, setStakingLimit } from "lib/protocol/helpers";
+import { ether } from "lib/units";
+
+import { Snapshot } from "test/suite";
+
+describe.only("Integration: VaultHub ", () => {
+  let ctx: ProtocolContext;
+  let snapshot: string;
+  let originalSnapshot: string;
+
+  let owner: HardhatEthersSigner;
+  let nodeOperator: HardhatEthersSigner;
+  let agentSigner: HardhatEthersSigner;
+  let stakingVault: StakingVault;
+
+  let vaultHub: VaultHub;
+  let dashboard: Dashboard;
+
+  before(async () => {
+    ctx = await getProtocolContext();
+    originalSnapshot = await Snapshot.take();
+
+    [, owner, nodeOperator] = await ethers.getSigners();
+    agentSigner = await ctx.getSigner("agent");
+    await setupLidoForVaults(ctx);
+  });
+
+  async function setup({ rr, frt }: { rr: bigint; frt: bigint }) {
+    ({ stakingVault, dashboard } = await createVaultWithDashboard(
+      ctx,
+      ctx.contracts.stakingVaultFactory,
+      owner,
+      nodeOperator,
+      nodeOperator,
+    ));
+
+    dashboard = dashboard.connect(owner);
+
+    const dashboardSigner = await impersonate(dashboard, ether("10000"));
+
+    await ctx.contracts.operatorGrid.connect(agentSigner).registerGroup(nodeOperator, ether("5000"));
+    const tier = {
+      shareLimit: ether("1000"),
+      reserveRatioBP: rr,
+      forcedRebalanceThresholdBP: frt,
+      infraFeeBP: 0,
+      liquidityFeeBP: 0,
+      reservationFeeBP: 0,
+    };
+
+    await ctx.contracts.operatorGrid.connect(agentSigner).registerTiers(nodeOperator, [tier]);
+    const beforeInfo = await ctx.contracts.operatorGrid.vaultInfo(stakingVault);
+    expect(beforeInfo.tierId).to.equal(0n);
+
+    const requestedTierId = 1n;
+    const requestedShareLimit = ether("1000");
+
+    // First confirmation from vault owner via Dashboard → returns false (not yet confirmed)
+    await dashboard.connect(owner).changeTier(requestedTierId, requestedShareLimit);
+
+    // Second confirmation from node operator → completes and updates connection
+    await ctx.contracts.operatorGrid
+      .connect(nodeOperator)
+      .changeTier(stakingVault, requestedTierId, requestedShareLimit);
+
+    const afterInfo = await ctx.contracts.operatorGrid.vaultInfo(stakingVault);
+    expect(afterInfo.tierId).to.equal(requestedTierId);
+
+    vaultHub = ctx.contracts.vaultHub.connect(dashboardSigner);
+
+    const connection = await vaultHub.vaultConnection(stakingVault);
+    expect(connection.shareLimit).to.equal(tier.shareLimit);
+    expect(connection.reserveRatioBP).to.equal(tier.reserveRatioBP);
+    expect(connection.forcedRebalanceThresholdBP).to.equal(tier.forcedRebalanceThresholdBP);
+
+    return {
+      stakingVault,
+      dashboard,
+      vaultHub,
+    };
+  }
+
+  beforeEach(async () => (snapshot = await Snapshot.take()));
+  afterEach(async () => await Snapshot.restore(snapshot));
+  after(async () => await Snapshot.restore(originalSnapshot));
+
+  // Helpers for precise threshold targeting with rounding accounted for
+  const B = 10000n; // basis points base
+
+  function ceilDiv(a: bigint, b: bigint) {
+    return (a + b - 1n) / b;
+  }
+
+  // Returns { liabETH, frtBP } for the current state
+  async function currentLiabilityEthAndFRT(ctx: ProtocolContext, vaultHub: VaultHub, stakingVault: StakingVault) {
+    const liabShares = await vaultHub.liabilityShares(stakingVault);
+    const liabETH = await ctx.contracts.lido.getPooledEthBySharesRoundUp(liabShares);
+    const { forcedRebalanceThresholdBP: frtBP } = await vaultHub.vaultConnection(stakingVault);
+    return { liabETH, frtBP };
+  }
+
+  // TV boundary s.t. vault is healthy when TV >= boundary, unhealthy when TV < boundary:
+  // liabilityETH <= TV * (B - T) / B  =>  TV >= ceil(liabilityETH * B / (B - T))
+  async function thresholdBoundaryTV(ctx: ProtocolContext, vaultHub: VaultHub, stakingVault: StakingVault) {
+    const { liabETH, frtBP } = await currentLiabilityEthAndFRT(ctx, vaultHub, stakingVault);
+    const denom = B - frtBP;
+    return ceilDiv(liabETH * B, denom);
+  }
+
+  describe("Shortfall", () => {
+    it("Works on larger numbers", async () => {
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 2000n }));
+
+      await vaultHub.fund(stakingVault, { value: ether("1") });
+      expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
+
+      await dashboard.mintShares(owner, ether("0.689"));
+
+      await reportVaultDataWithProof(ctx, stakingVault, {
+        totalValue: ether("1"), // slash 5%
+        waitForNextRefSlot: true,
+      });
+
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.false;
+      const shortfall = await vaultHub.healthShortfallShares(stakingVault);
+      await dashboard.connect(owner).rebalanceVaultWithShares(shortfall);
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.true;
+    });
+
+    it("Works on max capacity", async () => {
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 1000n, frt: 800n }));
+      await vaultHub.fund(stakingVault, { value: ether("9") });
+      expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("10"));
+
+      const maxShares = await dashboard.remainingMintingCapacityShares(0);
+
+      await dashboard.mintShares(owner, maxShares);
+
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.true;
+
+      await reportVaultDataWithProof(ctx, stakingVault, {
+        totalValue: (ether("10") * 95n) / 100n, // slash 5%
+        waitForNextRefSlot: true,
+      });
+
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.false;
+      const shortfall = await vaultHub.healthShortfallShares(stakingVault);
+      await dashboard.connect(owner).rebalanceVaultWithShares(shortfall);
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.true;
+    });
+
+    it("Works on small numbers", async () => {
+      ({ stakingVault, dashboard, vaultHub } = await setup({ rr: 2000n, frt: 2000n }));
+
+      await vaultHub.fund(stakingVault, { value: ether("1") });
+      expect(await vaultHub.totalValue(stakingVault)).to.equal(ether("2"));
+
+      await dashboard.mintShares(owner, 689n);
+
+      await reportVaultDataWithProof(ctx, stakingVault, {
+        totalValue: 1000n,
+        waitForNextRefSlot: true,
+      });
+
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.false;
+      const shortfall = await vaultHub.healthShortfallShares(stakingVault);
+      console.log(shortfall);
+      await dashboard.connect(owner).rebalanceVaultWithShares(shortfall);
+      const shortfall2 = await vaultHub.healthShortfallShares(stakingVault);
+      console.log(shortfall2);
+      expect(await vaultHub.isVaultHealthy(stakingVault)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
A short summary of the changes.

## Context
#1305 
 
---

Math


- LS = liability shares
- TVS = total value in shares (floor)
- B = 10000 (basis points base)
- T = thresholdBP
- M = B - T = mintRatio in bp.
- X = shortfall (misleading name btw)

---
Vault is healthy if:

`LS / TVS <= M / B`

or

`LS * B <= TVS * M`

---

Rebalance does the following

`LS - X`

rebalance(roundUp(X))

and

`TVS - Y`

Normally, `X == Y`

BUT

because rebalance rounds UP, in the worst case scenario

`Y = X + 1`

thus, we can derive the post-rebalance condition:

`(LS - X) * B <= (TVS - X - 1) * M`

OR (using distributive property)

`LS * B - X * B <= TVS * M - X * M - M` 

add `X * M` to both sides

`LS * B - X * B + X * M <= TVS * M - M` 

subtract `LS * B`

`- X * B + X * M <= TVS * M - M - LS * B` 

or factor X

`X (M - B) <= TVS * M - M - LS * B`

because

`T = M - B`

`X * (-T) <= TVS * M - M - LS * B`

divide both sides by -T and flip the sign

`X >= (TVS * M - M - LS * B) / (-T) `

move minus to numerator

`X >= -(TVS * M - M - LS * B) / T `

factor -1

`X >= (-TVS * M + M + L * B) / T `

rearrange and get the final inequality

**`X >= (L * B - TVS * M + M) / T `**

AND after all of that we need to use ceiling division because the final inequality also includes division

**`X >= (L * B - TVS * M + M) + (T - 1) /  T`**

---
 