### PR TITLE
fix: overflow in node operator fee

### DIFF
--- a/test/0.8.25/vaults/nodeOperatorFee/nodeOperatorFee.test.ts
+++ b/test/0.8.25/vaults/nodeOperatorFee/nodeOperatorFee.test.ts
@@ -377,6 +377,12 @@ describe("NodeOperatorFee.sol", () => {
       );
     });
 
+    it("reverts if the amount is too large", async () => {
+      await expect(
+        nodeOperatorFee.connect(nodeOperatorFeeExempter).addFeeExemption(2n ** 104n + 1n),
+      ).to.be.revertedWithCustomError(nodeOperatorFee, "UnexpectedFeeExemptionAmount");
+    });
+
     it("adjuster can addFeeExemption", async () => {
       const increase = ether("10");
 


### PR DESCRIPTION
what if in the addFeeExemption the NO gives a max_int128 _exemptedAmount then the settledGrowth is max_int128. if there is any slashing which the NO can cause, the onwer cannot dissconnect since he cannot _calculateFee() (udnerflow in unsettledGrowth calculation) and cannot pay it. this locks the owner
