### PR TITLE
fix(scratch): pass scratch-vs-upgrade to deployStakingModules explicitly

### DIFF
--- a/scripts/scratch/steps/0135-deploy-staking-modules.ts
+++ b/scripts/scratch/steps/0135-deploy-staking-modules.ts
@@ -7,5 +7,5 @@ export async function main() {
   const deployer = (await ethers.provider.getSigner()).address;
   const state = readNetworkState({ deployer });
 
-  await deployStakingModules(state);
+  await deployStakingModules(state, { scratch: true });
 }

--- a/scripts/upgrade/steps/0135-deploy-staking-modules.ts
+++ b/scripts/upgrade/steps/0135-deploy-staking-modules.ts
@@ -13,5 +13,5 @@ export async function main() {
 
   await logScriptHeader("SRv3/CMv2 — Deploy Staking Modules (CSM/CMv2)", deployer);
 
-  await deployStakingModules(state);
+  await deployStakingModules(state, { scratch: false });
 }

--- a/scripts/utils/staking-modules.ts
+++ b/scripts/utils/staking-modules.ts
@@ -2,7 +2,6 @@ import { execFileSync } from "child_process";
 import { HDNodeWallet } from "ethers";
 import fs from "fs";
 import { ethers, network as hardhatNetwork } from "hardhat";
-import { getMode } from "hardhat.helpers";
 import os from "os";
 import path from "path";
 import {
@@ -122,9 +121,14 @@ export function getEnvParams() {
   const rawChain = process.env.NETWORK;
   return {
     chain: typeof rawChain === "string" && CHAINS.includes(rawChain as Chain) ? (rawChain as Chain) : DEFAULT_CHAIN,
-    isScratch: getMode() === "scratch",
   };
 }
+
+export type StakingModulesDeployOptions = {
+  /// @dev `true` = fresh modules (`deploy-csm`), `false` = new implementations over the proxies in state
+  ///      (`deploy-csm-impl`). Not derived from `MODE`: a scratch deploy on an external RPC runs as `forking`.
+  scratch: boolean;
+};
 
 function getRpcUrl() {
   const networkConfig = hardhatNetwork.config;
@@ -309,9 +313,12 @@ export function saveCuratedArtifact(state: DeploymentState, artifact: ExternalDe
  * Clones the external community-staking-module repo and deploys the Community Staking Module (CSM)
  * and Curated Module v2 (CMv2), saving their addresses into the deployment state file.
  *
- * Shared between the scratch deploy step and the protocol upgrade step.
+ * Shared between the scratch deploy step and the protocol upgrade step; the caller says which one it is.
  */
-export async function deployStakingModules(state: DeploymentState): Promise<void> {
+export async function deployStakingModules(
+  state: DeploymentState,
+  { scratch: isScratch }: StakingModulesDeployOptions,
+): Promise<void> {
   // A module counts as deployed only once BOTH its proxy address and its deploy artifact are recorded.
   // During an upgrade the proxies are pre-written into the state file before the new implementations are
   // deployed, so the proxy address alone must not suppress the deploy.
@@ -361,7 +368,7 @@ export async function deployStakingModules(state: DeploymentState): Promise<void
     );
     run("just", ["deps"], tmpDir, process.env);
 
-    const { isScratch, chain } = getEnvParams();
+    const { chain } = getEnvParams();
     const artifactsDir = "./artifacts/local/";
 
     const externalEnv = {


### PR DESCRIPTION
## What

`deployStakingModules` picked the scratch vs upgrade path from `MODE === "scratch"`. The calling steps now pass it explicitly: `scripts/scratch/steps/0135` → `{ scratch: true }`, `scripts/upgrade/steps/0135` → `{ scratch: false }`. `getEnvParams()` only resolves the chain now.

## Why

`MODE` describes how the Hardhat network is configured (`scratch` = in-memory, `forking` = fork or external RPC), not which migration is running. A scratch deploy against a live devnet node has to run with `MODE=forking` (`MODE=scratch` removes the network state file and overrides `GENESIS_TIME`), so step 0135 took the upgrade branch, ran `deploy-csm-impl` and died on `vm.readFile … csm/deploy-local-devnet.json: No such file or directory` — after steps 0000–0130, with no resume. Reproduced on several local devnets; the workaround so far was trimming 0135 out of `steps.json` and deploying CSM/CMv2 separately.

## Behaviour change

None for existing flows: the in-memory scratch run (`MODE=scratch`) still deploys fresh modules, the upgrade steps still deploy implementations only. Only a scratch deploy on an external RPC changes — it now does what the step name says.

## Checks

- `yarn typecheck` clean, `eslint --max-warnings=0` clean on the changed files.
