### PR TITLE
feat: add VaultViewer tooling contract and deploy tooling in scratch

### DIFF
--- a/.github/workflows/tests-integration-hoodi.yml
+++ b/.github/workflows/tests-integration-hoodi.yml
@@ -29,7 +29,9 @@ jobs:
 
       # https://github.com/foundry-rs/foundry-toolchain
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        with:
+          version: v1.7.1
 
       - name: Install just
         run: cargo install just

--- a/.github/workflows/tests-integration-mainnet.yml
+++ b/.github/workflows/tests-integration-mainnet.yml
@@ -29,7 +29,9 @@ jobs:
 
       # https://github.com/foundry-rs/foundry-toolchain
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        with:
+          version: v1.7.1
 
       - name: Install just
         run: cargo install just

--- a/.github/workflows/tests-integration-scratch.yml
+++ b/.github/workflows/tests-integration-scratch.yml
@@ -27,7 +27,9 @@ jobs:
 
       # https://github.com/foundry-rs/foundry-toolchain
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        with:
+          version: v1.7.1
 
       - name: Install just
         run: cargo install just

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -28,7 +28,9 @@ jobs:
         uses: ./.github/workflows/setup
 
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        with:
+          version: v1.7.1
         # Use a specific version of Foundry in case nightly is broken
         # https://github.com/foundry-rs/foundry/releases
         # with:
@@ -52,7 +54,9 @@ jobs:
         uses: ./.github/workflows/setup
 
       - name: Install foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        with:
+          version: v1.7.1
 
       - name: Print forge version
         run: forge --version

--- a/contracts/tooling/VaultViewer.sol
+++ b/contracts/tooling/VaultViewer.sol
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: UNLICENSED
+// for tooling purposes only
+
+// ================================================================================================================= //
+// DISCLAIMER: This contract is intended solely for tooling and is NOT an official component of the Lido core protocol.
+// It is excluded from the Lido bug bounty program.
+// This contract has not undergone security auditing and its interface or functionality may change without notice.
+// ================================================================================================================= //
+
+// See contracts/COMPILERS.md
+pragma solidity 0.8.25;
+
+import { VaultHub } from "contracts/0.8.25/vaults/VaultHub.sol";
+import { IStakingVault } from "contracts/0.8.25/vaults/interfaces/IStakingVault.sol";
+import { ILido } from "contracts/common/interfaces/ILido.sol";
+import { ILidoLocator } from "contracts/common/interfaces/ILidoLocator.sol";
+import { LazyOracle } from "contracts/0.8.25/vaults/LazyOracle.sol";
+
+/// @title VaultViewer
+/// @dev this contract is NOT a part of the Lido core protocol logic, it is only used for tooling purposes
+contract VaultViewer {
+    struct VaultData {
+        address vaultAddress;
+        VaultHub.VaultConnection connection;
+        VaultHub.VaultRecord record;
+        uint256 totalValue;
+        uint256 liabilityStETH;
+        uint256 nodeOperatorFeeRate;
+        uint256 accruedFee;
+        bool isReportFresh;
+        LazyOracle.QuarantineInfo quarantineInfo;
+    }
+
+    struct VaultMembers {
+        address vault;
+        address owner;
+        address nodeOperator;
+        address[][] members;
+    }
+
+    /**
+     * @notice Strict true value for checking role membership
+     */
+    bytes32 private constant STRICT_TRUE = keccak256(hex"0000000000000000000000000000000000000000000000000000000000000001");
+
+    /**
+     * @notice Default admin role for checking roles
+     */
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    ILidoLocator public immutable LIDO_LOCATOR;
+    VaultHub public immutable VAULT_HUB;
+    LazyOracle public immutable LAZY_ORACLE;
+
+    /// @notice Constructor
+    /// @param _lidoLocator Address of the lido locator
+    constructor(address _lidoLocator) {
+        if (_lidoLocator == address(0)) revert ZeroArgument("_lidoLocator");
+        LIDO_LOCATOR = ILidoLocator(_lidoLocator);
+
+        VAULT_HUB = VaultHub(payable(LIDO_LOCATOR.vaultHub()));
+        LAZY_ORACLE = LazyOracle(LIDO_LOCATOR.lazyOracle());
+    }
+
+    /// @notice Checks if a given address is the owner of a connection vault
+    /// @param vault The vault to check
+    /// @param _owner The address to check
+    /// @return True if the address is the owner, false otherwise
+    function isVaultOwner(IStakingVault vault, address _owner) public view returns (bool) {
+        // For connected vaults the `vault.owner()` is VaultHub
+        VaultHub.VaultConnection memory connection = VAULT_HUB.vaultConnection(address(vault));
+        if (connection.owner == address(0)) {
+            return false;
+        }
+        if (connection.owner == _owner) {
+            return true;
+        }
+
+        return _checkHasRole(connection.owner, _owner, DEFAULT_ADMIN_ROLE);
+    }
+
+    /// @notice Checks if a given address has a given role on a connection vault owner contract
+    /// @param vault The vault to check
+    /// @param _member The address to check
+    /// @param _role The role to check
+    /// @return True if the address has the role, false otherwise
+    /// @dev Return roles only for connection vault owner - dashboard contract
+    function hasRole(IStakingVault vault, address _member, bytes32 _role) public view returns (bool) {
+        // For connected vaults the `vault.owner()` is VaultHub
+        VaultHub.VaultConnection memory connection = VAULT_HUB.vaultConnection(address(vault));
+        if (connection.owner == address(0)) {
+            return false;
+        }
+
+        return _checkHasRole(connection.owner, _member, _role);
+    }
+
+    /// @notice Returns vaults owned by `_owner` using batch pagination over the global vault list
+    /// @param _owner Address of the owner
+    /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
+    /// @param _limit Maximum number of vaults to SCAN (must be > 0)
+    /// @return vaults Array of owner-matching vaults found within the scanned window (length <= _limit)
+    function vaultsByOwnerBatch(
+        address _owner,
+        uint256 _offset,
+        uint256 _limit
+    ) public view returns (IStakingVault[] memory vaults) {
+        _requireNotZero(_limit, "_limit");
+
+        VaultHub vaultHub = VAULT_HUB;
+        uint256 count = vaultHub.vaultsCount();
+
+        if (_offset >= count) {
+            return new IStakingVault[](0);
+        }
+
+        uint256 remaining = count - _offset;
+        uint256 scanSize = _limit > remaining ? remaining : _limit;
+
+        vaults = new IStakingVault[](scanSize);
+        IStakingVault vault;
+        uint256 matchedCount = 0;
+
+        uint256 end = _offset + scanSize;
+        uint256 i = _offset;
+        for (; i < end; ) {
+            // vaultByIndex is 1-based, _offset is 0-based → add +1
+            vault = IStakingVault(vaultHub.vaultByIndex(i + 1));
+            if (isVaultOwner(vault, _owner)) {
+                vaults[matchedCount] = vault;
+                unchecked {
+                    ++matchedCount;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        // shrink to actual length
+        assembly { mstore(vaults, matchedCount) }
+    }
+
+    /// @notice Returns vaults where `_member` has `_role`, scanning a batch of the global vault list
+    /// @param _role Role to check
+    /// @param _member Address to check for the role
+    /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
+    /// @param _limit Maximum number of vaults to SCAN (must be > 0)
+    /// @return vaults Array of vaults where `_member` has `_role` found within the scanned window (length ≤ _limit)
+    function vaultsByRoleBatch(
+        bytes32 _role,
+        address _member,
+        uint256 _offset,
+        uint256 _limit
+    ) public view returns (IStakingVault[] memory vaults) {
+        _requireNotZero(_limit, "_limit");
+
+        VaultHub vaultHub = VAULT_HUB;
+        uint256 count = vaultHub.vaultsCount();
+
+        if (_offset >= count) {
+            return new IStakingVault[](0);
+        }
+
+        uint256 remaining = count - _offset;
+        uint256 scanSize = _limit > remaining ? remaining : _limit;
+
+        vaults = new IStakingVault[](scanSize);
+        IStakingVault vault;
+        uint256 matchedCount = 0;
+
+        uint256 end = _offset + scanSize;
+        uint256 i = _offset;
+        for (; i < end; ) {
+            // vaultByIndex is 1-based, _offset is 0-based → add +1
+            vault = IStakingVault(vaultHub.vaultByIndex(i + 1));
+            if (hasRole(vault, _member, _role)) {
+                vaults[matchedCount] = vault;
+                unchecked {
+                    ++matchedCount;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        // shrink to actual number of matches
+        assembly { mstore(vaults, matchedCount) }
+    }
+
+    /// @notice returns the number of vaults connected to the VaultHub
+    /// @return the number of vaults connected to the VaultHub
+    function vaultsCount() external view returns (uint256) {
+        return VAULT_HUB.vaultsCount();
+    }
+
+    /// @notice Returns aggregated data for a single vault
+    /// @param vault Address of the vault
+    /// @return data Aggregated vault data
+    function vaultData(address vault) public view returns (VaultData memory data) {
+        ILido lido = VAULT_HUB.LIDO();
+        VaultHub.VaultConnection memory connection = VAULT_HUB.vaultConnection(vault);
+        VaultHub.VaultRecord memory record = VAULT_HUB.vaultRecord(vault);
+        uint256 nodeOperatorFeeRate = _getNodeOperatorFeeRate(connection.owner);
+        uint256 accruedFee = _getAccruedFee(connection.owner);
+        LazyOracle.QuarantineInfo memory quarantineInfo = LAZY_ORACLE.vaultQuarantine(vault);
+
+        data = VaultData({
+            vaultAddress: vault,
+            connection: connection,
+            record: record,
+            totalValue: VAULT_HUB.totalValue(vault),
+            liabilityStETH: lido.getPooledEthBySharesRoundUp(record.liabilityShares),
+            nodeOperatorFeeRate: nodeOperatorFeeRate,
+            accruedFee: accruedFee,
+            isReportFresh: VAULT_HUB.isReportFresh(vault),
+            quarantineInfo: quarantineInfo
+        });
+    }
+
+    /// @notice Returns aggregated data for a batch of vaults
+    /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
+    /// @param _limit Maximum number of vaults to return (must be > 0)
+    /// @return vaultsData Array of aggregated vault data (length <= _limit)
+    function vaultsDataBatch(uint256 _offset, uint256 _limit) external view returns (VaultData[] memory vaultsData) {
+        _requireNotZero(_limit, "_limit");
+
+        VaultHub vaultHub = VAULT_HUB;
+        uint256 count = vaultHub.vaultsCount();
+
+        if (_offset >= count) {
+            return new VaultData[](0);
+        }
+
+        uint256 remaining = count - _offset;
+        uint256 batchSize = _limit > remaining ? remaining : _limit;
+
+        vaultsData = new VaultData[](batchSize);
+        for (uint256 i = 0; i < batchSize; ) {
+            // vaultByIndex is 1-based, _offset is 0-based → add +1
+            address vaultAddress = vaultHub.vaultByIndex(_offset + i + 1);
+            vaultsData[i] = vaultData(vaultAddress);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Returns vault addresses for a range of vaults
+    /// @param _offset Zero-based offset in the vaults list [0, vaultsCount)
+    /// @param _limit Maximum number of vaults to return (must be > 0)
+    /// @return vaults Array of vault contracts (IStakingVault)
+    function vaultAddressesBatch(uint256 _offset, uint256 _limit) public view returns (IStakingVault[] memory vaults) {
+        _requireNotZero(_limit, "_limit");
+
+        VaultHub vaultHub = VAULT_HUB;
+        uint256 count = vaultHub.vaultsCount();
+
+        if (_offset >= count) {
+            return new IStakingVault[](0);
+        }
+
+        uint256 remaining = count - _offset;
+        uint256 batchSize = _limit > remaining ? remaining : _limit;
+
+        vaults = new IStakingVault[](batchSize);
+        for (uint256 i = 0; i < batchSize; ) {
+            // vaultByIndex is 1-based, _offset is 0-based → add +1
+            address vaultAddress = vaultHub.vaultByIndex(_offset + i + 1);
+            vaults[i] = IStakingVault(vaultAddress);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Returns the VaultMembers for each specified role on a single vault
+    /// @param vaultAddress The address of the vault
+    /// @param roles An array of role identifiers (bytes32) to query on the vault’s owner contract
+    /// @return result VaultMembers containing vault address, owner, nodeOperator, and corresponding role members
+    function roleMembers(
+        address vaultAddress,
+        bytes32[] calldata roles
+    ) public view returns (VaultMembers memory result) {
+        VaultHub.VaultConnection memory connection = VAULT_HUB.vaultConnection(vaultAddress);
+        // For connected vaults the `vaultContract.owner()` is VaultHub
+        // connection.owner is the owner of the vault - dashboard contract
+        result.vault = vaultAddress;
+        result.owner = connection.owner;
+        result.nodeOperator = _getNodeOperatorAddress(vaultAddress);
+        result.members = new address[][](roles.length);
+
+        // owner may be an EOA wallet
+        if (!_isContract(result.owner)) {
+            return result;
+        }
+
+        for (uint256 i = 0; i < roles.length; i++) {
+            result.members[i] = _getRoleMember(result.owner, roles[i]);
+        }
+        return result;
+    }
+
+    /// @notice Returns VaultMembers for each role on multiple vaults
+    /// @param vaultAddresses Array of vault addresses to query
+    /// @param roles Array of roles to check for each vault
+    /// @return result Array of VaultMembers containing vault address, owner, nodeOperator and corresponding role members
+    function roleMembersBatch(
+        address[] calldata vaultAddresses,
+        bytes32[] calldata roles
+    ) external view returns (VaultMembers[] memory result) {
+        result = new VaultMembers[](vaultAddresses.length);
+
+        for (uint256 i = 0; i < vaultAddresses.length; i++) {
+            result[i] = roleMembers(vaultAddresses[i], roles);
+        }
+    }
+
+    // ==================== Internal Functions ====================
+
+    /// @notice Safely attempt a staticcall to `getRoleMembers(bytes32)` on the owner address
+    /// @dev common logic for roleMembers
+    /// @dev More gas-efficient to do any `_isContract(owner)` check in the caller
+    /// @param owner The address to call (may be a contract or an EOA)
+    /// @param role The role identifier
+    /// @return members Array of addresses if the call succeeds and returns a well-formed `address[]`; empty array otherwise
+    function _getRoleMember(address owner, bytes32 role) internal view returns (address[] memory members) {
+        (bool success, bytes memory data) = owner.staticcall(abi.encodeWithSignature("getRoleMembers(bytes32)", role));
+        if (!success || data.length < 64) return members;
+
+        // Validate the ABI layout before decoding: abi.decode reverts on a malformed offset/length or dirty address words
+        uint256 offset;
+        uint256 length;
+        assembly {
+            offset := mload(add(data, 32))
+            length := mload(add(data, 64))
+        }
+        if (offset != 32 || length > (data.length - 64) / 32) return members;
+
+        for (uint256 i = 0; i < length; ++i) {
+            uint256 word;
+            assembly {
+                word := mload(add(data, add(96, mul(i, 32))))
+            }
+            if (word > type(uint160).max) return members;
+        }
+
+        members = abi.decode(data, (address[]));
+    }
+
+    /// @notice safely returns if role member has given role
+    /// @param _contract that can have ACL or not
+    /// @param _member addrress to check for role
+    /// @param _role ACL role bytes
+    /// @return bool status of check
+    function _checkHasRole(address _contract, address _member, bytes32 _role) internal view returns (bool) {
+        if (!_isContract(_contract)) return false;
+
+        bytes memory payload = abi.encodeWithSignature("hasRole(bytes32,address)", _role, _member);
+        (bool success, bytes memory result) = _contract.staticcall(payload);
+
+        if (success && keccak256(result) == STRICT_TRUE) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /// @notice Tries to fetch nodeOperator - feeRate() from the vault owner if it's a dashboard contract
+    /// @dev Uses low-level staticcall to avoid reverting when the method is missing or the address is an EOA
+    /// @param owner The address of the vault owner (can be either a contract or an EOA)
+    /// @return fee The decoded fee value if present, otherwise 0
+    function _getNodeOperatorFeeRate(address owner) internal view returns (uint256 fee) {
+        if (_isContract(owner)) {
+            // if dashboard contract and have feeRate method
+            (bool success, bytes memory result) = owner.staticcall(abi.encodeWithSignature("feeRate()"));
+            // Check ensures safe decoding — avoids abi.decode revert on short return data
+            if (success && result.length >= 32) {
+                fee = abi.decode(result, (uint256));
+            }
+        }
+    }
+
+    /// @notice Tries to fetch accruedFee() from the vault owner if it's a dashboard contract
+    /// @dev Uses low-level staticcall to avoid reverting when the method is missing or the address is an EOA
+    /// @param owner The address of the vault owner (can be either a contract or an EOA)
+    /// @return accruedFee The decoded fee value if present, otherwise 0
+    function _getAccruedFee(address owner) internal view returns (uint256 accruedFee) {
+        if (_isContract(owner)) {
+            // if dashboard contract and have accruedFee method
+            (bool success, bytes memory result) = owner.staticcall(abi.encodeWithSignature("accruedFee()"));
+            // Check ensures safe decoding — avoids abi.decode revert on short return data
+            if (success && result.length >= 32) {
+                accruedFee = abi.decode(result, (uint256));
+            }
+        }
+    }
+
+    /// @notice Tries to fetch nodeOperator() from the vault contract
+    /// @dev Uses low-level staticcall to avoid reverting when the method is missing or vault is not a valid contract
+    /// @param vault The address of the vault (must be a contract implementing nodeOperator())
+    /// @return operator The decoded nodeOperator address if present, otherwise address(0)
+    /// @custom:todo Think about the need for this method
+    function _getNodeOperatorAddress(address vault) internal view returns (address operator) {
+        if (_isContract(vault)) {
+            (bool success, bytes memory result) = vault.staticcall(abi.encodeWithSignature("nodeOperator()"));
+            // Check ensures safe decoding — avoids abi.decode revert on short return data or dirty upper bits
+            if (success && result.length >= 32) {
+                uint256 word = abi.decode(result, (uint256));
+                if (word <= type(uint160).max) operator = address(uint160(word));
+            }
+        }
+    }
+
+    /// @notice Checks if a given address is a contract
+    /// @param account The address to check
+    /// @return True if the address is a contract, false otherwise
+    function _isContract(address account) internal view returns (bool) {
+        uint256 size;
+        assembly {
+            size := extcodesize(account)
+        }
+        return size > 0;
+    }
+
+    /// @notice Reverts if a provided numeric argument is zero
+    /// @param _value The argument value to validate
+    /// @param _argName The name of the argument
+    /// @custom:error ZeroArgument Thrown when `_value` equals zero
+    function _requireNotZero(uint256 _value, string memory _argName) internal pure {
+        if (_value == 0) revert ZeroArgument(_argName);
+    }
+
+    // ==================== Errors ====================
+
+    /// @notice Error for zero address arguments
+    /// @param argName Name of the argument that is zero
+    error ZeroArgument(string argName);
+}

--- a/lib/state-file.ts
+++ b/lib/state-file.ts
@@ -129,6 +129,7 @@ export enum Sk {
   vaultsAdapter = "vaultsAdapter",
   // Harnesses
   alertingHarness = "alertingHarness",
+  vaultViewer = "vaultViewer",
   // protocol upgrade
   upgradeConfig = "upgradeConfig",
   upgradeTemplate = "upgradeTemplate",
@@ -219,6 +220,9 @@ export function getAddress(contractKey: Sk, state: DeploymentState): string {
     case Sk.upgradeVoteScript:
     case Sk.gateSealFactory:
       return state[contractKey].address;
+    case Sk.alertingHarness:
+    case Sk.vaultViewer:
+      return state[contractKey].implementation.address;
     default:
       throw new Error(`Unsupported contract entry key ${contractKey}`);
   }

--- a/scripts/scratch/steps.json
+++ b/scripts/scratch/steps.json
@@ -12,6 +12,7 @@
     "scratch/steps/0083-deploy-core",
     "scratch/steps/0085-deploy-vaults",
     "scratch/steps/0090-upgrade-locator",
+    "scratch/steps/0095-deploy-tooling",
     "scratch/steps/0100-deploy-circuit-breaker",
     "scratch/steps/0101-deploy-easytrack",
     "scratch/steps/0110-finalize-dao",

--- a/scripts/scratch/steps/0095-deploy-tooling.ts
+++ b/scripts/scratch/steps/0095-deploy-tooling.ts
@@ -1,0 +1,16 @@
+import { ethers } from "hardhat";
+
+import { deployImplementation } from "lib/deploy";
+import { readNetworkState, Sk } from "lib/state-file";
+
+// Tooling contracts are not part of the protocol, they only read protocol state via the locator.
+// Deployed after the locator upgrade because VaultViewer resolves VaultHub and LazyOracle in its constructor.
+export async function main() {
+  const deployer = (await ethers.provider.getSigner()).address;
+  const state = readNetworkState({ deployer });
+
+  const locatorAddress = state[Sk.lidoLocator].proxy.address;
+
+  await deployImplementation(Sk.alertingHarness, "AlertingHarness", deployer, [locatorAddress]);
+  await deployImplementation(Sk.vaultViewer, "VaultViewer", deployer, [locatorAddress]);
+}

--- a/test/tooling/contracts/VaultOwnerACL__MockForVaultViewer.sol
+++ b/test/tooling/contracts/VaultOwnerACL__MockForVaultViewer.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+// for testing purposes only
+
+pragma solidity 0.8.25;
+
+import {AccessControlEnumerable} from "@openzeppelin/contracts-v5.2/access/extensions/AccessControlEnumerable.sol";
+
+/// @dev Dashboard-like vault owner: enumerable ACL plus node operator fee getters
+contract VaultOwnerACL__MockForVaultViewer is AccessControlEnumerable {
+    uint256 public feeRate;
+    uint256 public accruedFee;
+
+    constructor(address _admin, uint256 _feeRate, uint256 _accruedFee) {
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+        feeRate = _feeRate;
+        accruedFee = _accruedFee;
+    }
+}

--- a/test/tooling/contracts/VaultOwner__MockForVaultViewer.sol
+++ b/test/tooling/contracts/VaultOwner__MockForVaultViewer.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+// for testing purposes only
+
+pragma solidity 0.8.25;
+
+/// @dev vault owner contract without ACL: every call hits the fallback and returns `response` (empty by default)
+contract VaultOwner__MockForVaultViewer {
+    bytes public response;
+
+    function mock__setResponse(bytes calldata _response) external {
+        response = _response;
+    }
+
+    fallback() external {
+        bytes memory r = response;
+        assembly {
+            return(add(r, 32), mload(r))
+        }
+    }
+}

--- a/test/tooling/vaultViewer.test.ts
+++ b/test/tooling/vaultViewer.test.ts
@@ -1,0 +1,414 @@
+import { expect } from "chai";
+import { MaxUint256, ZeroAddress } from "ethers";
+import { ethers } from "hardhat";
+
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+import {
+  LazyOracle__MockForVaultHub,
+  Lido,
+  LidoLocator,
+  StakingVault__MockForVaultHub,
+  VaultHub,
+  VaultOwnerACL__MockForVaultViewer,
+  VaultViewer,
+} from "typechain-types";
+
+import { ether } from "lib";
+
+import { deployVaults } from "test/deploy/vaults";
+import { Snapshot } from "test/suite";
+
+describe("VaultViewer.sol", () => {
+  let deployer: HardhatEthersSigner;
+  let user: HardhatEthersSigner;
+  let operator: HardhatEthersSigner;
+  let stranger: HardhatEthersSigner;
+
+  let lido: Lido;
+  let locator: LidoLocator;
+  let vaultHub: VaultHub;
+  let lazyOracle: LazyOracle__MockForVaultHub;
+  let vaultViewer: VaultViewer;
+
+  let createMockStakingVaultAndConnect: (
+    owner: HardhatEthersSigner,
+    operator: HardhatEthersSigner,
+  ) => Promise<StakingVault__MockForVaultHub>;
+
+  let reportVaultHelper: (report: { vault: StakingVault__MockForVaultHub; totalValue?: bigint }) => Promise<void>;
+
+  let originalState: string;
+
+  before(async () => {
+    [deployer, user, operator, stranger] = await ethers.getSigners();
+
+    const vaultsSetup = await deployVaults({ deployer, admin: user });
+    lido = vaultsSetup.lido;
+    vaultHub = vaultsSetup.vaultHub;
+    lazyOracle = vaultsSetup.lazyOracle;
+    createMockStakingVaultAndConnect = vaultsSetup.createMockStakingVaultAndConnect;
+    reportVaultHelper = vaultsSetup.reportVault;
+
+    locator = await ethers.getContractAt("LidoLocator", await lido.getLidoLocator(), deployer);
+
+    vaultViewer = await ethers.deployContract("VaultViewer", [await locator.getAddress()]);
+  });
+
+  beforeEach(async () => (originalState = await Snapshot.take()));
+
+  afterEach(async () => await Snapshot.restore(originalState));
+
+  describe("constructor", () => {
+    it("reverts if locator is zero address", async () => {
+      await expect(ethers.deployContract("VaultViewer", [ZeroAddress])).to.be.revertedWithCustomError(
+        vaultViewer,
+        "ZeroArgument",
+      );
+    });
+
+    it("resolves protocol contracts from the locator", async () => {
+      expect(await vaultViewer.LIDO_LOCATOR()).to.equal(await locator.getAddress());
+      expect(await vaultViewer.VAULT_HUB()).to.equal(await vaultHub.getAddress());
+      expect(await vaultViewer.LAZY_ORACLE()).to.equal(await lazyOracle.getAddress());
+    });
+  });
+
+  describe("vaultsCount", () => {
+    it("mirrors VaultHub.vaultsCount", async () => {
+      expect(await vaultViewer.vaultsCount()).to.equal(0n);
+
+      await createMockStakingVaultAndConnect(user, operator);
+      await createMockStakingVaultAndConnect(user, operator);
+
+      expect(await vaultViewer.vaultsCount()).to.equal(2n);
+    });
+  });
+
+  describe("vaultAddressesBatch", () => {
+    it("reverts on zero limit", async () => {
+      await expect(vaultViewer.vaultAddressesBatch(0, 0)).to.be.revertedWithCustomError(vaultViewer, "ZeroArgument");
+    });
+
+    it("returns empty array when no vaults exist", async () => {
+      expect(await vaultViewer.vaultAddressesBatch(0, 10)).to.have.length(0);
+    });
+
+    it("respects offset and limit", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      const vault2 = await createMockStakingVaultAndConnect(user, operator);
+      const vault3 = await createMockStakingVaultAndConnect(user, operator);
+
+      const batch = await vaultViewer.vaultAddressesBatch(1, 2);
+      expect(batch).to.deep.equal([await vault2.getAddress(), await vault3.getAddress()]);
+    });
+
+    it("returns partial batch when offset + limit exceeds vault count", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      const vault2 = await createMockStakingVaultAndConnect(user, operator);
+
+      const batch = await vaultViewer.vaultAddressesBatch(1, 10);
+      expect(batch).to.deep.equal([await vault2.getAddress()]);
+    });
+
+    it("returns empty array when offset exceeds vault count", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+
+      expect(await vaultViewer.vaultAddressesBatch(100, 10)).to.have.length(0);
+    });
+
+    it("does not overflow on max limit", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      const vault2 = await createMockStakingVaultAndConnect(user, operator);
+
+      const batch = await vaultViewer.vaultAddressesBatch(1, MaxUint256);
+      expect(batch).to.deep.equal([await vault2.getAddress()]);
+    });
+  });
+
+  describe("vaultData", () => {
+    it("returns aggregated data for a connected vault", async () => {
+      const vault = await createMockStakingVaultAndConnect(user, operator);
+      await reportVaultHelper({ vault, totalValue: ether("100") });
+      await lazyOracle.mock__setIsVaultQuarantined(await vault.getAddress(), true);
+
+      const data = await vaultViewer.vaultData(await vault.getAddress());
+
+      expect(data.vaultAddress).to.equal(await vault.getAddress());
+      expect(data.connection.owner).to.equal(user.address);
+      expect(data.connection.vaultIndex).to.equal(1n);
+      expect(data.record.report.totalValue).to.equal(ether("100"));
+      expect(data.totalValue).to.equal(await vaultHub.totalValue(vault));
+      expect(data.liabilityStETH).to.equal(0n);
+      // owner is an EOA, so dashboard fee getters are not available
+      expect(data.nodeOperatorFeeRate).to.equal(0n);
+      expect(data.accruedFee).to.equal(0n);
+      expect(data.isReportFresh).to.equal(await vaultHub.isReportFresh(vault));
+      expect(data.quarantineInfo.isActive).to.equal(true);
+    });
+  });
+
+  describe("vaultsDataBatch", () => {
+    it("reverts on zero limit", async () => {
+      await expect(vaultViewer.vaultsDataBatch(0, 0)).to.be.revertedWithCustomError(vaultViewer, "ZeroArgument");
+    });
+
+    it("returns empty array when no vaults exist", async () => {
+      expect(await vaultViewer.vaultsDataBatch(0, 10)).to.have.length(0);
+    });
+
+    it("returns data for vaults in the window", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      const vault2 = await createMockStakingVaultAndConnect(user, operator);
+      const vault3 = await createMockStakingVaultAndConnect(user, operator);
+      await reportVaultHelper({ vault: vault2, totalValue: ether("200") });
+
+      const batch = await vaultViewer.vaultsDataBatch(1, 10);
+
+      expect(batch).to.have.length(2);
+      expect(batch[0].vaultAddress).to.equal(await vault2.getAddress());
+      expect(batch[0].record.report.totalValue).to.equal(ether("200"));
+      expect(batch[1].vaultAddress).to.equal(await vault3.getAddress());
+    });
+
+    it("does not overflow on max limit", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      await createMockStakingVaultAndConnect(user, operator);
+
+      expect(await vaultViewer.vaultsDataBatch(1, MaxUint256)).to.have.length(1);
+    });
+  });
+
+  describe("isVaultOwner", () => {
+    it("returns true for the connection owner", async () => {
+      const vault = await createMockStakingVaultAndConnect(user, operator);
+
+      expect(await vaultViewer.isVaultOwner(vault, user)).to.equal(true);
+    });
+
+    it("returns false for a stranger", async () => {
+      const vault = await createMockStakingVaultAndConnect(user, operator);
+
+      expect(await vaultViewer.isVaultOwner(vault, stranger)).to.equal(false);
+    });
+
+    it("returns false for zero address on a vault that is not connected", async () => {
+      expect(await vaultViewer.isVaultOwner(stranger, ZeroAddress)).to.equal(false);
+    });
+  });
+
+  describe("hasRole", () => {
+    it("returns false when the owner is an EOA", async () => {
+      const vault = await createMockStakingVaultAndConnect(user, operator);
+
+      expect(await vaultViewer.hasRole(vault, user, await vaultViewer.DEFAULT_ADMIN_ROLE())).to.equal(false);
+    });
+
+    it("returns false for a vault that is not connected", async () => {
+      expect(await vaultViewer.hasRole(stranger, user, await vaultViewer.DEFAULT_ADMIN_ROLE())).to.equal(false);
+    });
+  });
+
+  describe("vaultsByOwnerBatch", () => {
+    it("reverts on zero limit", async () => {
+      await expect(vaultViewer.vaultsByOwnerBatch(user, 0, 0)).to.be.revertedWithCustomError(
+        vaultViewer,
+        "ZeroArgument",
+      );
+    });
+
+    it("returns only vaults owned by the given address", async () => {
+      const vault1 = await createMockStakingVaultAndConnect(user, operator);
+      await createMockStakingVaultAndConnect(stranger, operator);
+      const vault3 = await createMockStakingVaultAndConnect(user, operator);
+
+      const batch = await vaultViewer.vaultsByOwnerBatch(user, 0, 10);
+      expect(batch).to.deep.equal([await vault1.getAddress(), await vault3.getAddress()]);
+    });
+
+    it("scans only the requested window", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      const vault2 = await createMockStakingVaultAndConnect(user, operator);
+      await createMockStakingVaultAndConnect(user, operator);
+
+      const batch = await vaultViewer.vaultsByOwnerBatch(user, 1, 1);
+      expect(batch).to.deep.equal([await vault2.getAddress()]);
+    });
+
+    it("returns empty array when offset exceeds vault count", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+
+      expect(await vaultViewer.vaultsByOwnerBatch(user, 100, 10)).to.have.length(0);
+    });
+
+    it("does not overflow on max limit", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      const vault2 = await createMockStakingVaultAndConnect(user, operator);
+
+      const batch = await vaultViewer.vaultsByOwnerBatch(user, 1, MaxUint256);
+      expect(batch).to.deep.equal([await vault2.getAddress()]);
+    });
+  });
+
+  describe("vaultsByRoleBatch", () => {
+    it("returns empty array when owners are EOAs", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      await createMockStakingVaultAndConnect(user, operator);
+
+      const batch = await vaultViewer.vaultsByRoleBatch(await vaultViewer.DEFAULT_ADMIN_ROLE(), user, 0, 10);
+      expect(batch).to.have.length(0);
+    });
+
+    it("does not overflow on max limit", async () => {
+      await createMockStakingVaultAndConnect(user, operator);
+      await createMockStakingVaultAndConnect(user, operator);
+
+      const batch = await vaultViewer.vaultsByRoleBatch(await vaultViewer.DEFAULT_ADMIN_ROLE(), user, 1, MaxUint256);
+      expect(batch).to.have.length(0);
+    });
+  });
+
+  describe("roleMembers", () => {
+    it("returns vault, owner and node operator with empty members for an EOA owner", async () => {
+      const vault = await createMockStakingVaultAndConnect(user, operator);
+      const roles = [await vaultViewer.DEFAULT_ADMIN_ROLE(), ethers.id("SOME_ROLE")];
+
+      const members = await vaultViewer.roleMembers(vault, roles);
+
+      expect(members.vault).to.equal(await vault.getAddress());
+      expect(members.owner).to.equal(user.address);
+      expect(members.nodeOperator).to.equal(operator.address);
+      expect(members.members).to.deep.equal([[], []]);
+    });
+
+    it("returns empty members when the owner contract has no ACL and answers with empty data", async () => {
+      const vault = await createMockStakingVaultAndConnect(user, operator);
+      const ownerMock = await ethers.deployContract("VaultOwner__MockForVaultViewer");
+      await vaultHub.connect(user).transferVaultOwnership(vault, ownerMock);
+      const roles = [await vaultViewer.DEFAULT_ADMIN_ROLE()];
+
+      const members = await vaultViewer.roleMembers(vault, roles);
+
+      expect(members.owner).to.equal(await ownerMock.getAddress());
+      expect(members.members).to.deep.equal([[]]);
+      expect(await vaultViewer.hasRole(vault, user, roles[0])).to.equal(false);
+    });
+  });
+
+  describe("ACL owner", () => {
+    const FEE_RATE = 500n;
+    const ACCRUED_FEE = ether("1");
+    const CUSTOM_ROLE = ethers.id("CUSTOM_ROLE");
+
+    let vault: StakingVault__MockForVaultHub;
+    let owner: VaultOwnerACL__MockForVaultViewer;
+    let adminRole: string;
+
+    beforeEach(async () => {
+      vault = await createMockStakingVaultAndConnect(user, operator);
+      owner = await ethers.deployContract("VaultOwnerACL__MockForVaultViewer", [user, FEE_RATE, ACCRUED_FEE]);
+      await vaultHub.connect(user).transferVaultOwnership(vault, owner);
+      await owner.connect(user).grantRole(CUSTOM_ROLE, stranger);
+      adminRole = await vaultViewer.DEFAULT_ADMIN_ROLE();
+    });
+
+    it("hasRole matches the owner ACL", async () => {
+      expect(await vaultViewer.hasRole(vault, user, adminRole)).to.equal(true);
+      expect(await vaultViewer.hasRole(vault, stranger, adminRole)).to.equal(false);
+      expect(await vaultViewer.hasRole(vault, stranger, CUSTOM_ROLE)).to.equal(true);
+      expect(await vaultViewer.hasRole(vault, user, CUSTOM_ROLE)).to.equal(false);
+    });
+
+    it("isVaultOwner treats the owner admin as the vault owner", async () => {
+      expect(await vaultViewer.isVaultOwner(vault, owner)).to.equal(true);
+      expect(await vaultViewer.isVaultOwner(vault, user)).to.equal(true);
+      expect(await vaultViewer.isVaultOwner(vault, stranger)).to.equal(false);
+    });
+
+    it("vaultsByOwnerBatch and vaultsByRoleBatch find the vault through the ACL", async () => {
+      await createMockStakingVaultAndConnect(stranger, operator);
+
+      expect(await vaultViewer.vaultsByOwnerBatch(user, 0, 10)).to.deep.equal([await vault.getAddress()]);
+      expect(await vaultViewer.vaultsByRoleBatch(adminRole, user, 0, 10)).to.deep.equal([await vault.getAddress()]);
+      expect(await vaultViewer.vaultsByRoleBatch(CUSTOM_ROLE, stranger, 0, 10)).to.deep.equal([
+        await vault.getAddress(),
+      ]);
+      expect(await vaultViewer.vaultsByRoleBatch(CUSTOM_ROLE, user, 0, 10)).to.have.length(0);
+    });
+
+    it("roleMembers returns the members of each role", async () => {
+      const members = await vaultViewer.roleMembers(vault, [adminRole, CUSTOM_ROLE, ethers.id("EMPTY_ROLE")]);
+
+      expect(members.owner).to.equal(await owner.getAddress());
+      expect(members.nodeOperator).to.equal(operator.address);
+      expect(members.members).to.deep.equal([[user.address], [stranger.address], []]);
+    });
+
+    it("vaultData reads the node operator fee getters from the owner", async () => {
+      const data = await vaultViewer.vaultData(vault);
+
+      expect(data.nodeOperatorFeeRate).to.equal(FEE_RATE);
+      expect(data.accruedFee).to.equal(ACCRUED_FEE);
+    });
+  });
+
+  describe("malformed owner responses", () => {
+    const abi = ethers.AbiCoder.defaultAbiCoder();
+
+    async function connectWithFallbackOwner(response: string) {
+      const vault = await createMockStakingVaultAndConnect(user, operator);
+      const owner = await ethers.deployContract("VaultOwner__MockForVaultViewer");
+      await owner.mock__setResponse(response);
+      await vaultHub.connect(user).transferVaultOwnership(vault, owner);
+      return vault;
+    }
+
+    it("decodes a well-formed address[] returned by a fallback", async () => {
+      const vault = await connectWithFallbackOwner(abi.encode(["address[]"], [[stranger.address]]));
+
+      const members = await vaultViewer.roleMembers(vault, [ethers.id("ROLE")]);
+      expect(members.members).to.deep.equal([[stranger.address]]);
+    });
+
+    it("returns empty members on a bad offset", async () => {
+      const vault = await connectWithFallbackOwner(abi.encode(["uint256", "uint256"], [64, 1]));
+
+      const members = await vaultViewer.roleMembers(vault, [ethers.id("ROLE")]);
+      expect(members.members).to.deep.equal([[]]);
+    });
+
+    it("returns empty members on a length larger than the payload", async () => {
+      const vault = await connectWithFallbackOwner(abi.encode(["uint256", "uint256"], [32, MaxUint256]));
+
+      const members = await vaultViewer.roleMembers(vault, [ethers.id("ROLE")]);
+      expect(members.members).to.deep.equal([[]]);
+    });
+
+    it("returns empty members on a dirty address word", async () => {
+      const vault = await connectWithFallbackOwner(abi.encode(["uint256", "uint256", "uint256"], [32, 1, MaxUint256]));
+
+      const members = await vaultViewer.roleMembers(vault, [ethers.id("ROLE")]);
+      expect(members.members).to.deep.equal([[]]);
+    });
+
+    it("hasRole is false unless the response is exactly true", async () => {
+      const vault = await connectWithFallbackOwner(abi.encode(["uint256"], [2]));
+
+      expect(await vaultViewer.hasRole(vault, user, ethers.id("ROLE"))).to.equal(false);
+    });
+  });
+
+  describe("roleMembersBatch", () => {
+    it("returns one entry per requested vault", async () => {
+      const vault1 = await createMockStakingVaultAndConnect(user, operator);
+      const vault2 = await createMockStakingVaultAndConnect(stranger, operator);
+      const roles = [await vaultViewer.DEFAULT_ADMIN_ROLE()];
+
+      const result = await vaultViewer.roleMembersBatch([vault1, vault2], roles);
+
+      expect(result).to.have.length(2);
+      expect(result[0].owner).to.equal(user.address);
+      expect(result[1].owner).to.equal(stranger.address);
+    });
+  });
+});


### PR DESCRIPTION
Moves `VaultViewer` from `si-lidity` to `contracts/tooling/` next to `AlertingHarness`.

## Context

Collecting harness contracts in `core` so they track protocol contracts and ship with scratch. Tooling only, not audited.

## Solution

- `VaultViewer.sol` with hardening against malformed owner responses: layout-validated `getRoleMembers` decoding, `uint160` check on `nodeOperator()`, `offset + limit` overflow, zero-owner check in `isVaultOwner`.
- Scratch step `0095-deploy-tooling` deploys `AlertingHarness` and `VaultViewer`.
- `Sk.vaultViewer`, `getAddress` support for tooling keys.
- 39 unit tests, including a Dashboard-like ACL owner and malformed fallback responses.
- CI: `foundry-toolchain` pinned to v1.9.1 with forge v1.7.1, same as `feat/edf`. The v1.8.0 action fails to run `foundryup`, and forge 1.8.1 breaks `forge test` (`ds-test` remapping) and the CSM deploy in scratch (`ReentrancySentryOOG`).